### PR TITLE
Migrate haproxy v1.4.3

### DIFF
--- a/packages/haproxy/haproxy.patch
+++ b/packages/haproxy/haproxy.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/haproxy/charts-original/Chart.yaml packages/haproxy/charts/Chart.yaml
+--- packages/haproxy/charts-original/Chart.yaml
++++ packages/haproxy/charts/Chart.yaml
+@@ -18,3 +18,7 @@
+ sources:
+ - https://github.com/haproxytech/kubernetes-ingress
+ version: 1.4.3
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: kubernetes-ingress
++  catalog.cattle.io/release-name: kubernetes-ingress

--- a/packages/haproxy/haproxy.patch
+++ b/packages/haproxy/haproxy.patch
@@ -1,11 +1,16 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/haproxy/charts-original/Chart.yaml packages/haproxy/charts/Chart.yaml
 --- packages/haproxy/charts-original/Chart.yaml
 +++ packages/haproxy/charts/Chart.yaml
-@@ -18,3 +18,7 @@
+@@ -14,7 +14,11 @@
+   name: Baptiste Assmann
+ - email: dkorunic@haproxy.com
+   name: Dinko Korunic
+-name: kubernetes-ingress
++name: haproxy
  sources:
  - https://github.com/haproxytech/kubernetes-ingress
  version: 1.4.3
 +annotations:
 +  catalog.cattle.io/certified: partner
-+  catalog.cattle.io/namespace: kubernetes-ingress
-+  catalog.cattle.io/release-name: kubernetes-ingress
++  catalog.cattle.io/namespace: haproxy
++  catalog.cattle.io/release-name: haproxy

--- a/packages/haproxy/overlay/app-readme.yml
+++ b/packages/haproxy/overlay/app-readme.yml
@@ -1,0 +1,8 @@
+# HAProxy
+[HAProxy](https://www.haproxy.org/) is the world's fastest and most widely used software load balancer. HAProxy allows organizations to deliver websites and applications with the utmost performance, observability, and security at any scale and in any environment.
+
+# HAProxy Enterprise
+[HAProxy Enterprise](https://www.haproxy.com/products/haproxy-enterprise-edition/)  is an enterprise-class version of HAProxy providing a robust and reliable code base with cutting edge features, an enterprise suite of add-ons, expert support, and professional services. At its core, it incorporates feature backports from the HAProxy development branch for customers who require immediate access to the latest functionality in a hardened version of code.
+
+## Introduction
+This chart bootstraps the [HAProxy Ingress Controller](https://github.com/haproxytech/kubernetes-ingress) or the [HAProxy Enterprise Ingress Controller](https://www.haproxy.com/products/haproxy-enterprise-kubernetes-ingress-controller/) using the [Helm](https://helm.sh) package manager.

--- a/packages/haproxy/overlay/questions.yml
+++ b/packages/haproxy/overlay/questions.yml
@@ -1,0 +1,80 @@
+categories:
+- Ingress
+- Proxy
+- Loadbalancer
+labels:
+  io.cattle.role: cluster
+  io.rancher.certified: partner
+questions:
+- variable: imageDefault
+  default: true
+  description: "Use default Docker image"
+  label: Use Default Image
+  type: boolean
+  group: "Settings"
+  show_subquestion_if: false
+  subquestions:
+  - variable: controller.image.tag
+    default: "1.4.5"
+    description: "HAProxy Ingress Controller Tag"
+    type: string
+    label: HAProxy Ingress Controller Tag
+- variable: controller.kind
+  type: enum
+  options:
+    - "DaemonSet"
+    - "Deployment"
+  default: "Deployment"
+  description: "Deployment Type"
+  label: Deployment Type
+  group: "Settings"
+- variable: controller.service.type
+  type: enum
+  options:
+    - "LoadBalancer"
+    - "NodePort"
+  default: "NodePort"
+  description: "Service Type for HAProxy Ingress Controller"
+  label: Service Type
+  group: "Settings"
+- variable: controller.ingressClass
+  default: ""
+  description: "Ingress Class for targeting this controller"
+  label: Ingress Class
+  type: string
+  group: "Settings"
+- variable: controller.defaultTLSSecret.secret
+  default: ""
+  description: "Default TLS certificate secret"
+  label: TLS Certificate Secret
+  type: string
+  group: "Settings"
+- variable: enableEnterprise
+  default: false
+  description: "Use HAProxy Enterprise"
+  label: Enable
+  type: boolean
+  group: "HAProxy Enterprise"
+  show_subquestion_if: true
+  subquestions:
+  - variable: controller.imageCredentials.registry
+    type: string
+    default: "kubernetes-registry.haproxy.com"
+    description: "HAProxy Enterprise Registtry"
+    label: Registry
+  - variable: controller.image.repository
+    type: string
+    default: "kubernetes-registry.haproxy.com/hapee-ingress"
+    description: "HAProxy Enterprise Registry"
+    label: Repository
+  - variable: controller.imageCredentials.username
+    type: string
+    default: "MYUSERNAME"
+    description: "HAProxy Enterprise Username"
+    label: Username
+  - variable: controller.imageCredentials.password
+    type: string
+    default: "MYPASSWORD"
+    description: "HAProxy Enterprise Password"
+    label: Password 
+

--- a/packages/haproxy/overlay/questions.yml
+++ b/packages/haproxy/overlay/questions.yml
@@ -1,10 +1,3 @@
-categories:
-- Ingress
-- Proxy
-- Loadbalancer
-labels:
-  io.cattle.role: cluster
-  io.rancher.certified: partner
 questions:
 - variable: imageDefault
   default: true
@@ -15,7 +8,7 @@ questions:
   show_subquestion_if: false
   subquestions:
   - variable: controller.image.tag
-    default: "1.4.5"
+    default: "1.4.6"
     description: "HAProxy Ingress Controller Tag"
     type: string
     label: HAProxy Ingress Controller Tag

--- a/packages/haproxy/package.yaml
+++ b/packages/haproxy/package.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.4.3/kubernetes-ingress-1.4.3.tgz
+packageVersion: 00


### PR DESCRIPTION
Updates in chart:
- Update the chart's name to `haproxy` as they have previously done
this change in the old chart (probably to avoid confusion in the
Rancher UI).

Updates in questions.yaml to align with new chart values:
- Remove partner and role labels
- Remove categories
- Update default image tag