### PR TITLE
Migrate traefik v8.9.1

### DIFF
--- a/packages/traefik/overlay/app-readme.md
+++ b/packages/traefik/overlay/app-readme.md
@@ -1,0 +1,5 @@
+[Traefik](https://traefik.io/) is a modern HTTP reverse proxy and load balancer made to deploy
+microservices with ease.
+
+This chart bootstraps Traefik as a Kubernetes ingress controller with optional support for SSL and
+Let's Encrypt.

--- a/packages/traefik/overlay/app-readme.md
+++ b/packages/traefik/overlay/app-readme.md
@@ -1,5 +1,5 @@
 [Traefik](https://traefik.io/) is a modern HTTP reverse proxy and load balancer made to deploy
 microservices with ease.
 
-This chart bootstraps Traefik as a Kubernetes ingress controller with optional support for SSL and
-Let's Encrypt.
+This chart bootstraps Traefik version 2 as a Kubernetes ingress controller,
+using Custom Resources `IngressRoute`: <https://docs.traefik.io/providers/kubernetes-crd/>.

--- a/packages/traefik/overlay/questions.yml
+++ b/packages/traefik/overlay/questions.yml
@@ -1,0 +1,121 @@
+categories:
+- Proxy
+- Loadbalancer
+labels:
+  io.cattle.role: project
+  io.rancher.certified: partner
+questions:
+- variable: defaultImage
+  default: true
+  description: "Use default Docker image"
+  label: Use Default Image
+  type: boolean
+  group: "General Settings"
+  show_subquestion_if: false
+  subquestions:
+  - variable: imageTag
+    default: "1.7.14"
+    description: "Traefik Image Tag"
+    type: string
+    label: Traefik Image Tag
+- variable: serviceType
+  type: enum
+  options:
+    - "LoadBalancer"
+    - "NodePort"
+    - "ClusterIP"
+  default: "LoadBalancer"
+  description: "Service Type for Traefik"
+  label: Service Type
+  group: "General Settings"
+- variable: debug.enabled
+  type: boolean
+  default: false
+  description: "Enable Debug Mode"
+  label: Debug
+  group: "General Settings"
+- variable: rbac.enabled
+  default: true
+  description: "Enable RBAC Settings"
+  label: RBAC
+  type: boolean
+  group: "General Settings"
+- variable: ssl.enabled
+  type: boolean
+  default: false
+  description: "Enable SSL"
+  label: SSL
+  show_subquestion_if: true
+  group: "SSL"
+  subquestions:
+  - variable: ssl.enforced
+    type: boolean
+    default: false
+    description: "Force HTTP to HTTPS"
+    label: Http to HTTPS
+  - variable: ssl.permanentRedirect
+    type: boolean
+    default: false
+    description: "Permanentely Redirect HTTP to HTTPS"
+    label: Permanent Redirects
+- variable: acme.enabled
+  type: boolean
+  default: false
+  description: "Enable Lets Encrypt"
+  label: Lets Encrypt
+  show_subquestion_if: true
+  group: "Lets Encrypt (ACME Protocol)"
+  show_if: "ssl.enabled=true"
+  subquestions:
+  - variable: acme.email
+    type: string
+    default: "admin@example.com"
+    description: "E-Mail Adress to use"
+    label: E-Mail
+  - variable: acme.onHostRule
+    type: boolean
+    default: true
+    description: "Generate Lets Encrypt Certificates on the Fly"
+    label: On Host
+  - variable: acme.staging
+    type: boolean
+    default: true
+    description: "Generate Test Lets Encrypt Certificates to not use the Rate Limit"
+    label: Test Certificates (Staging)
+  - variable: acme.logging
+    type: boolean
+    default: true
+    description: "Activate Lets Encrypt Logging"
+    label: Logging
+  - variable: acme.challengeType
+    type: enum
+    options:
+      - "tls-alpn-01"
+      - "http-01"
+      - "dns-01"
+    default: "tls-alpn-01"
+    description: "Challengetype to use for Lets Encrypt Certificates"
+    label: Challengetype
+  - variable: persistence.enabled
+    type: boolean
+    default: true
+    description: "Enable Persistence for Lets Encrypt Certificates"
+    label: Persistence
+- variable: dashboard.enabled
+  default: false
+  description: "Enable Dashboard"
+  label: Enable
+  type: boolean
+  group: "Dashboard"
+  show_subquestion_if: true
+  subquestions:
+  - variable: dashboard.domain
+    type: string
+    default: "traefik.example.com"
+    description: "Hostname to use for dashboard"
+    label: Domain
+  - variable: dashboard.auth.basic
+    type: string
+    default: ""
+    description: "Basic-Aut Protection for Dashboard"
+    label: Basic Auth

--- a/packages/traefik/overlay/questions.yml
+++ b/packages/traefik/overlay/questions.yml
@@ -1,9 +1,3 @@
-categories:
-- Proxy
-- Loadbalancer
-labels:
-  io.cattle.role: project
-  io.rancher.certified: partner
 questions:
 - variable: defaultImage
   default: true
@@ -13,12 +7,12 @@ questions:
   group: "General Settings"
   show_subquestion_if: false
   subquestions:
-  - variable: imageTag
-    default: "1.7.14"
+  - variable: image.tag
+    default: "2.2.5"
     description: "Traefik Image Tag"
     type: string
     label: Traefik Image Tag
-- variable: serviceType
+- variable: service.type
   type: enum
   options:
     - "LoadBalancer"
@@ -28,94 +22,21 @@ questions:
   description: "Service Type for Traefik"
   label: Service Type
   group: "General Settings"
-- variable: debug.enabled
-  type: boolean
-  default: false
-  description: "Enable Debug Mode"
-  label: Debug
-  group: "General Settings"
 - variable: rbac.enabled
   default: true
   description: "Enable RBAC Settings"
   label: RBAC
   type: boolean
   group: "General Settings"
-- variable: ssl.enabled
+- variable: persistence.enabled
   type: boolean
-  default: false
-  description: "Enable SSL"
-  label: SSL
-  show_subquestion_if: true
-  group: "SSL"
-  subquestions:
-  - variable: ssl.enforced
-    type: boolean
-    default: false
-    description: "Force HTTP to HTTPS"
-    label: Http to HTTPS
-  - variable: ssl.permanentRedirect
-    type: boolean
-    default: false
-    description: "Permanentely Redirect HTTP to HTTPS"
-    label: Permanent Redirects
-- variable: acme.enabled
-  type: boolean
-  default: false
-  description: "Enable Lets Encrypt"
-  label: Lets Encrypt
-  show_subquestion_if: true
-  group: "Lets Encrypt (ACME Protocol)"
-  show_if: "ssl.enabled=true"
-  subquestions:
-  - variable: acme.email
-    type: string
-    default: "admin@example.com"
-    description: "E-Mail Adress to use"
-    label: E-Mail
-  - variable: acme.onHostRule
-    type: boolean
-    default: true
-    description: "Generate Lets Encrypt Certificates on the Fly"
-    label: On Host
-  - variable: acme.staging
-    type: boolean
-    default: true
-    description: "Generate Test Lets Encrypt Certificates to not use the Rate Limit"
-    label: Test Certificates (Staging)
-  - variable: acme.logging
-    type: boolean
-    default: true
-    description: "Activate Lets Encrypt Logging"
-    label: Logging
-  - variable: acme.challengeType
-    type: enum
-    options:
-      - "tls-alpn-01"
-      - "http-01"
-      - "dns-01"
-    default: "tls-alpn-01"
-    description: "Challengetype to use for Lets Encrypt Certificates"
-    label: Challengetype
-  - variable: persistence.enabled
-    type: boolean
-    default: true
-    description: "Enable Persistence for Lets Encrypt Certificates"
-    label: Persistence
-- variable: dashboard.enabled
-  default: false
-  description: "Enable Dashboard"
+  default: true
+  description: "Enable Persistence for TLS certificates"
+  label: Persistence
+- variable: ingressRoute.dashboard.enabled
+  default: true
+  description: "Enable Dashboard Ingress Route"
   label: Enable
   type: boolean
   group: "Dashboard"
-  show_subquestion_if: true
-  subquestions:
-  - variable: dashboard.domain
-    type: string
-    default: "traefik.example.com"
-    description: "Hostname to use for dashboard"
-    label: Domain
-  - variable: dashboard.auth.basic
-    type: string
-    default: ""
-    description: "Basic-Aut Protection for Dashboard"
-    label: Basic Auth
+ 

--- a/packages/traefik/package.yaml
+++ b/packages/traefik/package.yaml
@@ -1,0 +1,2 @@
+url: https://containous.github.io/traefik-helm-chart/traefik-8.9.1.tgz
+packageVersion: 00

--- a/packages/traefik/traefik.patch
+++ b/packages/traefik/traefik.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/traefik/charts-original/Chart.yaml packages/traefik/charts/Chart.yaml
+--- packages/traefik/charts-original/Chart.yaml
++++ packages/traefik/charts/Chart.yaml
+@@ -17,3 +17,7 @@
+ sources:
+ - https://github.com/containous/traefik
+ version: 8.9.1
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: traefik
++  catalog.cattle.io/release-name: traefik


### PR DESCRIPTION
**NEEDS FIX:**
- Can't access dashboard when enabled in questions by setting `ingressRoute.dashboard.enabled: true` (default is enabled).

Update app-readme based on their latest README.md
Updates in question.yaml to align with new chart values:
- Remove partner and role labels
- Remove categories
- Refactor variable names
- Update default image tag
- Remove debug mode as it's no longer available. Logging level can be
configured by passing flags to `additionalArguments`.
- Remove acme and ssl values as they are no longer available.