### PR TITLE
Migrate redskyops v0.2.2

### DIFF
--- a/packages/redskyops/overlay/app-readme.md
+++ b/packages/redskyops/overlay/app-readme.md
@@ -1,0 +1,6 @@
+# Red Sky Ops
+
+Red Sky Ops is an AIOps platform for deploying and optimizing containerized applications in Kubernetes environments. It makes it easy for DevOps teams to manage the millions of possible combinations of application variables they're confronted when deploying applications. With Red Sky Ops, they can identify and implement the best settings for each application in any cloud environment. Red Sky Ops allows teams to streamline their application tuning process and have a centralized, organized view of their tuning results.
+
+**Installation Note:** 
+It is recommended that you launch using the name **"redsky"**.

--- a/packages/redskyops/overlay/questions.yml
+++ b/packages/redskyops/overlay/questions.yml
@@ -1,6 +1,3 @@
-labels:
-  io.cattle.role: cluster # options are cluster/project
-  io.rancher.certified: partner
 questions:
 - variable: defaultImage
   default: true
@@ -11,35 +8,40 @@ questions:
   group: "Container Images"
   subquestions:
   - variable: redskyImage
-    default: "gcr.io/redskyops/k8s-experiment"
+    default: "redskyops/redskyops-controller"
     description: "Docker image name"
     type: string
     label: Image Name
   - variable: redskyTag
-    default: "1.2.2"
+    default: "1.6.0"
     description: "Docker image tag"
     type: string
     label: Image Tag
-- variable: remoteServerEnabled
+- variable: remoteServer.enabled
   default: false
-  description: "Use a remote Red Sky Ops server"
+  description: "Use a remote Red Sky API remote server"
   label: Use Remote Server
   type: boolean
   show_subquestion_if: true
   group: "Remote Server"
   subquestions:
-  - variable: address
+  - variable: remoteServer.identifier
     default: ""
-    description: "Fully qualified URL of the remote server"
+    description: "Identifier of the Red Sky API server"
     type: string
-    label: Address
-  - variable: oauth2ClientID
+    label: Identifier
+  - variable: remoteServer.issuer
     default: ""
-    description: "OAuth2 client identifier"
+    description: "Identifier of the Red Sky API authorization server"
+    type: string
+    label: Issuer
+  - variable: remoteServer.clientID
+    default: ""
+    description: "Unique client identifier assigned to the controller"
     type: string
     label: Client ID
-  - variable: oauth2ClientSecret
+  - variable: remoteServer.clientSecret
     default: ""
-    description: "OAuth2 client secret"
+    description: "Secret used to authenticate the controller"
     type: string
     label: Client Secret

--- a/packages/redskyops/overlay/questions.yml
+++ b/packages/redskyops/overlay/questions.yml
@@ -1,0 +1,45 @@
+labels:
+  io.cattle.role: cluster # options are cluster/project
+  io.rancher.certified: partner
+questions:
+- variable: defaultImage
+  default: true
+  description: "Use default Docker image"
+  label: Use Default Image
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: redskyImage
+    default: "gcr.io/redskyops/k8s-experiment"
+    description: "Docker image name"
+    type: string
+    label: Image Name
+  - variable: redskyTag
+    default: "1.2.2"
+    description: "Docker image tag"
+    type: string
+    label: Image Tag
+- variable: remoteServerEnabled
+  default: false
+  description: "Use a remote Red Sky Ops server"
+  label: Use Remote Server
+  type: boolean
+  show_subquestion_if: true
+  group: "Remote Server"
+  subquestions:
+  - variable: address
+    default: ""
+    description: "Fully qualified URL of the remote server"
+    type: string
+    label: Address
+  - variable: oauth2ClientID
+    default: ""
+    description: "OAuth2 client identifier"
+    type: string
+    label: Client ID
+  - variable: oauth2ClientSecret
+    default: ""
+    description: "OAuth2 client secret"
+    type: string
+    label: Client Secret

--- a/packages/redskyops/package.yaml
+++ b/packages/redskyops/package.yaml
@@ -1,0 +1,2 @@
+url: https://redskyops.dev/charts/redskyops-0.2.2.tgz
+packageVersion: 00

--- a/packages/redskyops/redskyops.patch
+++ b/packages/redskyops/redskyops.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/redskyops/charts-original/Chart.yaml packages/redskyops/charts/Chart.yaml
+--- packages/redskyops/charts-original/Chart.yaml
++++ packages/redskyops/charts/Chart.yaml
+@@ -9,3 +9,7 @@
+   name: redskyops
+ name: redskyops
+ version: 0.2.2
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: redskyops
++  catalog.cattle.io/release-name: redskyops


### PR DESCRIPTION
**NEEDS FIX:**
Gets stuck at `Removing` status when uninstalling. 
Shows `Waiting on helm-controller_c-n65l2`

 Update questions
- Remove role and partner labels
- Update default image repository and tag
- Refactor variable names to align with new chart values

