### PR TITLE
Migrate sysdig

### DIFF
--- a/packages/sysdig/overlay/app-readme.md
+++ b/packages/sysdig/overlay/app-readme.md
@@ -1,0 +1,20 @@
+# Sysdig Secure DevOps Platform
+
+Sysdig enables companies to confidently run cloud-native workloads in production. With the Sysdig Secure DevOps Platform, cloud teams embed security, maximize availability, and validate compliance. The Sysdig platform is open by design, with the scale, performance, and usability enterprises demand. The largest companies rely on Sysdig for cloud-native security and visibility. 
+
+## Embed security
+* Detect vulnerabilities and misconfigurations with a single workflow
+* Block threats without impacting performance using K8s controls
+* Conduct forensics even after the container is gone
+
+## Maximize availability
+* Prevent issues by monitoring performance and capacity 
+* Accelerate troubleshooting with a single source of truth
+* Scale Prometheus monitoring across clusters and clouds
+
+## Validate compliance
+* Verify configuration meets CIS best practices
+* Ensure application compliance with NIST, PCI
+* Enable audit by correlating Kubernetes activity
+
+Learn more at [sysdig.com](https://sysdig.com/)

--- a/packages/sysdig/overlay/questions.yml
+++ b/packages/sysdig/overlay/questions.yml
@@ -1,0 +1,104 @@
+labels:
+  io.rancher.certified: partner
+  io.cattle.role: cluster
+rancher_min_version: 2.3.0
+questions:
+#image configurations
+- variable: defaultImage
+  default: true
+  description: "Use default Sysdig image or specify a custom one"
+  label: Use Default Sysdig Image
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: image.repository
+    default: "ranchercharts/sysdig"
+    description: "Sysdig Image Name"
+    type: string
+    label: Sysdig Image Name
+  - variable: image.tag
+    default: "0.93.0"
+    description: "Sysdig Image Tag"
+    type: string
+    label: Sysdig Image Tag
+#agent configurations
+- variable: sysdig.accessKey
+  default: ""
+  description: "You need your Sysdig accessKey before running agents"
+  type: string
+  required: true
+  label: Sysdig accessKey
+- variable: sysdig.backend
+  default: "Sysdig SaaS"
+  description: "Where is Sysdig backend hosted on"
+  type: enum
+  label: Sysdig Backend
+  group: "Agent Configuration"
+  required: true
+  options:
+    - "sysdig-saas"
+    - "self-hosted"
+- variable: sysdig.settings.collector
+  required: true
+  default: "collector.sysdigcloud.com"
+  description: "The host of the Sysdig collector the agent sends data to, only set this option if you need the agent to send data to a custom backend"
+  type: string
+  label: Sysdig Collector
+  group: "Agent Configuration"
+  show_if: "sysdig.backed=self-hosted"
+- variable: sysdig.settings.collector_port
+  required: true
+  default: "6443"
+  description: "The port where the Sysdig collector listens to"
+  type: string
+  label: Sysdig Collector Port
+  group: "Agent Configuration"
+  show_if: "sysdig.backed=self-hosted"
+- variable: sysdig.settings.ssl
+  required: true
+  default: true
+  description: "Use SSL to connect to the Sysdig collector"
+  type: boolean
+  label: Sysdig Collector SSL
+  group: "Agent Configuration"
+  show_if: "sysdig.backed=self-hosted"
+- variable: sysdig.settings.ssl_verify_certificate
+  required: true
+  default: true
+  description: "Validate SSL certificate from the Sysdig collector"
+  type: boolean
+  label: Sysdig Collector Verify SSL Certificate
+  group: "Agent Configuration"
+  show_if: "sysdig.backed=self-hosted&&sysdig.settings.ssl=true"
+- variable: sysdig.settings.tags
+  default: ""
+  description: "Agent tags, separated by commas. For example: 'linux:ubuntu,dept:dev,local:nyc'"
+  type: string
+  label: Agent Tags
+  group: "Agent Configuration"
+- variable: ebpf.enabled
+  default: false
+  description: "Enable eBPF support for Sysdig agent instead of kernel module"
+  type: boolean
+  label: Enable eBPF
+  group: "Agent Configuration"
+#proxy configurations
+- variable: proxy.httpProxy
+  default: ""
+  description: "An http URL to use as a proxy for http requests"
+  type: string
+  label: Proxy for HTTP Requests
+  group: "Proxy Configuration"
+- variable: proxy.httpsProxy
+  default: ""
+  description: "An http URL to use as a proxy for https requests"
+  type: string
+  label: Proxy for HTTPS Requests
+  group: "Proxy Configuration"
+- variable: proxy.noProxy
+  default: ""
+  description: "A space-separated list of URLs for which no proxy should be used"
+  type: string
+  label: No Proxy List (separated by a space)
+  group: "Proxy Configuration"

--- a/packages/sysdig/overlay/questions.yml
+++ b/packages/sysdig/overlay/questions.yml
@@ -1,7 +1,3 @@
-labels:
-  io.rancher.certified: partner
-  io.cattle.role: cluster
-rancher_min_version: 2.3.0
 questions:
 #image configurations
 - variable: defaultImage
@@ -13,12 +9,12 @@ questions:
   group: "Container Images"
   subquestions:
   - variable: image.repository
-    default: "ranchercharts/sysdig"
+    default: "sysdig/agent"
     description: "Sysdig Image Name"
     type: string
     label: Sysdig Image Name
   - variable: image.tag
-    default: "0.93.0"
+    default: "10.3.0"
     description: "Sysdig Image Tag"
     type: string
     label: Sysdig Image Tag
@@ -46,7 +42,7 @@ questions:
   type: string
   label: Sysdig Collector
   group: "Agent Configuration"
-  show_if: "sysdig.backed=self-hosted"
+  show_if: "sysdig.backend=self-hosted"
 - variable: sysdig.settings.collector_port
   required: true
   default: "6443"
@@ -54,7 +50,7 @@ questions:
   type: string
   label: Sysdig Collector Port
   group: "Agent Configuration"
-  show_if: "sysdig.backed=self-hosted"
+  show_if: "sysdig.backend=self-hosted"
 - variable: sysdig.settings.ssl
   required: true
   default: true
@@ -62,7 +58,7 @@ questions:
   type: boolean
   label: Sysdig Collector SSL
   group: "Agent Configuration"
-  show_if: "sysdig.backed=self-hosted"
+  show_if: "sysdig.backend=self-hosted"
 - variable: sysdig.settings.ssl_verify_certificate
   required: true
   default: true
@@ -70,7 +66,7 @@ questions:
   type: boolean
   label: Sysdig Collector Verify SSL Certificate
   group: "Agent Configuration"
-  show_if: "sysdig.backed=self-hosted&&sysdig.settings.ssl=true"
+  show_if: "sysdig.backend=self-hosted&&sysdig.settings.ssl=true"
 - variable: sysdig.settings.tags
   default: ""
   description: "Agent tags, separated by commas. For example: 'linux:ubuntu,dept:dev,local:nyc'"

--- a/packages/sysdig/package.yaml
+++ b/packages/sysdig/package.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/sysdiglabs/charts/releases/download/sysdig-1.9.2/sysdig-1.9.2.tgz
+packageVersion: 00

--- a/packages/sysdig/sysdig.patch
+++ b/packages/sysdig/sysdig.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/sysdig/charts-original/Chart.yaml packages/sysdig/charts/Chart.yaml
+--- packages/sysdig/charts-original/Chart.yaml
++++ packages/sysdig/charts/Chart.yaml
+@@ -26,3 +26,7 @@
+ - https://app.sysdigcloud.com/#/settings/user
+ - https://github.com/draios/sysdig
+ version: 1.9.2
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: sysdig
++  catalog.cattle.io/release-name: sysdig


### PR DESCRIPTION
 **UNTESTED:**
An access key is needed for testing this. I created a free tier account and followed IBM's instructions to generate an access key. The agent fails to connect when using that access key and throws an error for invalid access key. The same behavior can be seen using the same access key in the old chart, so I believe a paid account might be needed to test this. 

Update questions
- Update default image repository and tag
- Remove role and partner labels
- Remove rancher minimum version constraint

