### PR TITLE
Migrate datadog v2.4.2

### DIFF
--- a/packages/datadog/datadog.patch
+++ b/packages/datadog/datadog.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/datadog/charts-original/Chart.yaml packages/datadog/charts/Chart.yaml
+--- packages/datadog/charts-original/Chart.yaml
++++ packages/datadog/charts/Chart.yaml
+@@ -15,3 +15,7 @@
+ - https://app.datadoghq.com/account/settings#agent/kubernetes
+ - https://github.com/DataDog/datadog-agent
+ version: 2.4.2
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: datadog
++  catalog.cattle.io/release-name: datadog

--- a/packages/datadog/overlay/app-readme.md
+++ b/packages/datadog/overlay/app-readme.md
@@ -1,0 +1,32 @@
+# Datadog
+
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
+
+Datadog [offers two variants](https://hub.docker.com/r/datadog/agent/tags/), switch to a `-jmx` tag if you need to run JMX/java integrations. The chart also supports running [the standalone dogstatsd image](https://hub.docker.com/r/datadog/dogstatsd/tags/).
+
+See the [Datadog JMX integration](https://docs.datadoghq.com/integrations/java/) to learn more.
+
+## Prerequisites
+
+Kubernetes 1.4+ or OpenShift 3.4+, note that:
+
+* the Datadog Agent supports Kubernetes 1.3+
+* The Datadog chart's defaults are tailored to Kubernetes 1.7.6+, see [Datadog Agent legacy Kubernetes versions documentation](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#legacy-kubernetes-versions) for adjustments you might need to make for older versions
+
+## Quick start
+
+By default, the Datadog Agent runs in a DaemonSet. It can alternatively run inside a Deployment for special use cases.
+
+**Note:** simultaneous DaemonSet + Deployment installation within a single release will be deprecated in a future version, requiring two releases to achieve this.
+
+### Installing the Datadog Chart
+
+To install the chart with the release name `<RELEASE_NAME>`, retrieve your Datadog API key from your [Agent Installation Instructions](https://app.datadoghq.com/account/settings#agent/kubernetes) and run:
+
+```bash
+helm install --name <RELEASE_NAME> \
+  --set datadog.apiKey=<DATADOG_API_KEY> stable/datadog
+```
+
+By default, this Chart creates a Secret and puts an API key in that Secret.
+However, you can use manually created secret by setting the `datadog.apiKeyExistingSecret` value. After a few minutes, you should see hosts and metrics being reported in Datadog.

--- a/packages/datadog/overlay/questions.yml
+++ b/packages/datadog/overlay/questions.yml
@@ -1,0 +1,231 @@
+labels:
+  io.rancher.certified: partner
+  io.cattle.role: cluster # options are cluster/project
+rancher_min_version: 2.3.0
+questions:
+#image configurations
+- variable: defaultImage
+  default: true
+  description: "Use default Datadog image or specify a custom one"
+  label: Use Default Datadog Image
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: agents.image.repository
+    default: "ranchercharts/datadog-agent"
+    description: "Datadog image name"
+    type: string
+    label: Datadog Image Name
+  - variable: agents.image.tag
+    default: "7"
+    description: "Datadog Image Tag"
+    type: string
+    label: Datadog Image Tag
+  - variable: clusterAgent.image.repository
+    default: "ranchercharts/datadog-cluster-agent"
+    description: "Datadog clusterAgent image name"
+    type: string
+    label: Datadog ClusterAgent Image Name
+  - variable: clusterAgent.image.tag
+    default: "1.5.2"
+    description: "Datadog ClusterAgent Image Tag"
+    type: string
+    label: Datadog ClusterAgent Image Tag
+  - variable: clusterChecksRunner.image.repository
+    default: "ranchercharts/datadog-agent"
+    description: "Datadog clusterChecksRunner image name"
+    type: string
+    label: Datadog Cluster Checks Runner Image Name
+    show_if: "clusterChecksRunner.enabled=true&&defaultImage=false"
+  - variable: clusterChecksRunner.image.tag
+    default: "7"
+    description: "Datadog  Cluster Checks Runner Image Tag"
+    type: string
+    label: Datadog Cluster Checks Runner Image Tag
+    show_if: "clusterChecksRunner.enabled=true&&defaultImage=false"
+  - variable: kube-state-metrics.image.repository
+    default: "ranchercharts/coreos-kube-state-metrics"
+    description: "KubeState image name"
+    type: string
+    label: KubeState Image Name
+    show_if: "kubeStateMetrics.enabled=true&&defaultImage=false"
+  - variable: kube-state-metrics.image.tag
+    default: "v1.7.2"
+    description: "KubeState Image Tag"
+    type: string
+    label: KubeState Image Tag
+    show_if: "kubeStateMetrics.enabled=true&&defaultImage=false"
+#cluster agent configurations
+- variable: clusterAgent.enabled
+  default: false
+  description: "Use the cluster-agent for cluster metrics (Kubernetes 1.10+ only), https://docs.datadoghq.com/agent/kubernetes/cluster/"
+  type: boolean
+  label: Enable Cluster Agent Metrics(Kubernetes 1.10+ only)
+  group: "Cluster Agent"
+- variable: clusterAgent.metricsProvider.enabled
+  default: true
+  description: "Enable the metricsProvider to be able to scale based on metrics in Datadog"
+  type: boolean
+  label: Enable the metricsProvider
+  show_if: "clusterAgent.enabled=true"
+  group: "Cluster Agent"
+- variable: datadog.appKey
+  default: ""
+  description: "Datadog App key required to use metricsProvider"
+  type: string
+  required: true
+  label: Datadog Metrics App Key
+  group: "Cluster Agent"
+  show_if: "clusterAgent.enabled=true&&clusterAgent.metricsProvider.enabled=true&&datadog.appKeyExistingSecret="
+- variable: datadog.appKeyExistingSecret
+  default: ""
+  description: "If set, use the secret with a provided name instead of creating a new appKey secret."
+  type: secret
+  label: Select Existing Datadog App Key(Secret)
+  group: "Cluster Agent"
+  show_if: "clusterAgent.enabled=true&&clusterAgent.metricsProvider.enabled=true&&datadog.appKey="
+#datadog agent configurations
+- variable: datadog.apiKey
+  default: ""
+  description: "Enter your Datadog API Key."
+  type: string
+  label: Datadog API Key
+  group: "Agent Configuration"
+  required: true
+  show_if: "datadog.apiKeyExistingSecret="
+- variable: datadog.apiKeyExistingSecret
+  default: ""
+  description: "If set, use the secret with a provided name instead of creating a new apiKey secret."
+  type: secret
+  label: Select Existing Datadog API Key(Secret)
+  group: "Agent Configuration"
+  show_if: "datadog.apiKey="
+- variable: datadog.site
+  default: "datadoghq.com"
+  description: "The site of the Datadog intake to send Agent data to"
+  type: enum
+  label: Datadog Site URL
+  group: "Agent Configuration"
+  required: true
+  options:
+    - "datadoghq.com"
+    - "datadoghq.eu"
+    - "custom"
+- variable: datadog.dd_url
+  required: true
+  default: ""
+  description: "The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL"
+  type: string
+  label: Datadog Custom Site URL
+  group: "Agent Configuration"
+  show_if: "datadog.site=custom"
+- variable: datadog.logLevel
+  default: "warn"
+  description: "Set Agent logging verbosity"
+  type: enum
+  options:
+    - "trace"
+    - "debug"
+    - "info"
+    - "warn"
+    - "error"
+    - "critical"
+    - "off"
+  label: Log Level
+  group: "Agent Configuration"
+- variable: datadog.tags
+  default: ""
+  description: "Host tags, separated by spaces. For example: 'simple-tag-0 tag-key-1:tag-value-1'"
+  type: string
+  label: Host Tags
+  group: "Agent Configuration"
+- variable: datadog.criSocketPath
+  default: ""
+  description: "Path to the container runtime socket (if different from Docker), default to `/var/run/docker.sock`"
+  type: string
+  label: Path To The Container Runtime Socket(Optional)
+  group: "Agent Configuration"
+- variable: datadog.dogstatsd.nonLocalTraffic
+  default: false
+  description: "Whether DogStatsD should listen to non local UDP traffic, required to send custom metrics"
+  type: boolean
+  label: DogStatsD Non-Local Traffic
+  group: "Agent Configuration"
+- variable: datadog.collectEvents
+  default: false
+  description: "Enable event collection from the kubernetes API"
+  type: boolean
+  label: Collect Events
+  group: "Agent Configuration"
+# Datadog Tagging 
+- variable: datadog.podLabelsAsTags
+  default: ""
+  description: "Specify a JSON map, where the map key is the source label name and the map value the datadog tag name. E.g: '{\"app\":\"kube_app\",\"release\":\"helm_release\"}'"
+  type: string
+  label: Extract Pod Labels as Tags
+  group: "Datadog Tagging"
+- variable: datadog.podAnnotationsAsTags
+  default: ""
+  description: "Specify a JSON map, where the map key is the source label name and the map value the datadog tag name. E.g: '{\"app\":\"kube_app\",\"release\":\"helm_release\"}'"
+  type: string
+  label: Extract Pod Annotations as Tags
+  group: "Datadog Tagging"
+- variable: datadog.nodeLabelsAsTags
+  default: ""
+  description: "Specify a JSON map, where the map key is the source label name and the map value the datadog tag name. E.g: '{\"app\":\"kube_app\",\"release\":\"helm_release\"}'"
+  type: string
+  label: Extract Node Labels As Tags
+  group: "Datadog Tagging"
+# DaemonSet configurations
+- variable: agents.rkeETCDControlPlane
+  default: true
+  description: "Configure Datadog Agent pods with the required tolerations to be deployed on the RKE etcd and control plane."
+  type: boolean
+  label: Run datadog pod on RKE Control Plane Nodes
+  group: "Daemonset Configuration"
+- variable: agents.useHostNetwork
+  default: false
+  description: "Bind ports on the hostNetwork. Useful for CNI networking where hostPort might not be supported. The ports will need to be available on all hosts"
+  type: boolean
+  label: Use HostNetwork
+  group: "Daemonset Configuration"
+- variable: agents.dogstatsd.useHostPort
+  default: false
+  description: "Sets the hostPort to the same value of the container port"
+  type: boolean
+  label: Use HostPort
+  group: "Daemonset Configuration"
+- variable: agents.useHostPID
+  default: false
+  description: "Run the agent in the host's PID namespace"
+  type: boolean
+  label: Use HostPID
+  group: "Daemonset Configuration"
+# Optional Collection agents
+- variable: datadog.apm.enabled
+  default: false
+  description: "Run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp"
+  type: boolean
+  label: Enable APM
+  group: "Optional Collection Agents"
+- variable: datadog.processAgent.enabled
+  default: false
+  description: "Enable live process collection in the process-agent"
+  type: boolean
+  label: Enable Live Process Agent
+  group: "Optional Collection Agents"
+- variable: datadog.logs.enabled
+  default: false
+  description: "Run the log-agent along with the infrastructure agent"
+  type: boolean
+  label: Collect Logs
+  group: "Optional Collection Agents"
+
+#Kube State Metrics
+- variable: kubeStateMetrics.enabled
+  default: true
+  description: "Create a kube-state-metrics deployment"
+  type: boolean
+  label: Deployment KubeState Metrics Deployment
+  group: "Kube-State-Metrics"

--- a/packages/datadog/overlay/questions.yml
+++ b/packages/datadog/overlay/questions.yml
@@ -1,7 +1,3 @@
-labels:
-  io.rancher.certified: partner
-  io.cattle.role: cluster # options are cluster/project
-rancher_min_version: 2.3.0
 questions:
 #image configurations
 - variable: defaultImage
@@ -13,45 +9,45 @@ questions:
   group: "Container Images"
   subquestions:
   - variable: agents.image.repository
-    default: "ranchercharts/datadog-agent"
+    default: "datadog/agent"
     description: "Datadog image name"
     type: string
     label: Datadog Image Name
   - variable: agents.image.tag
-    default: "7"
+    default: "7.21.1"
     description: "Datadog Image Tag"
     type: string
     label: Datadog Image Tag
   - variable: clusterAgent.image.repository
-    default: "ranchercharts/datadog-cluster-agent"
+    default: "datadog/cluster-agent"
     description: "Datadog clusterAgent image name"
     type: string
     label: Datadog ClusterAgent Image Name
   - variable: clusterAgent.image.tag
-    default: "1.5.2"
+    default: "1.7.0"
     description: "Datadog ClusterAgent Image Tag"
     type: string
     label: Datadog ClusterAgent Image Tag
   - variable: clusterChecksRunner.image.repository
-    default: "ranchercharts/datadog-agent"
+    default: "datadog/agent"
     description: "Datadog clusterChecksRunner image name"
     type: string
     label: Datadog Cluster Checks Runner Image Name
     show_if: "clusterChecksRunner.enabled=true&&defaultImage=false"
   - variable: clusterChecksRunner.image.tag
-    default: "7"
+    default: "7.21.1"
     description: "Datadog  Cluster Checks Runner Image Tag"
     type: string
     label: Datadog Cluster Checks Runner Image Tag
     show_if: "clusterChecksRunner.enabled=true&&defaultImage=false"
   - variable: kube-state-metrics.image.repository
-    default: "ranchercharts/coreos-kube-state-metrics"
+    default: "quay.io/coreos/kube-state-metrics"
     description: "KubeState image name"
     type: string
     label: KubeState Image Name
     show_if: "kubeStateMetrics.enabled=true&&defaultImage=false"
   - variable: kube-state-metrics.image.tag
-    default: "v1.7.2"
+    default: "v1.9.7"
     description: "KubeState Image Tag"
     type: string
     label: KubeState Image Tag
@@ -178,12 +174,6 @@ questions:
   label: Extract Node Labels As Tags
   group: "Datadog Tagging"
 # DaemonSet configurations
-- variable: agents.rkeETCDControlPlane
-  default: true
-  description: "Configure Datadog Agent pods with the required tolerations to be deployed on the RKE etcd and control plane."
-  type: boolean
-  label: Run datadog pod on RKE Control Plane Nodes
-  group: "Daemonset Configuration"
 - variable: agents.useHostNetwork
   default: false
   description: "Bind ports on the hostNetwork. Useful for CNI networking where hostPort might not be supported. The ports will need to be available on all hosts"

--- a/packages/datadog/package.yaml
+++ b/packages/datadog/package.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/DataDog/helm-charts/releases/download/datadog-2.4.2/datadog-2.4.2.tgz
+packageVersion: 00


### PR DESCRIPTION
 Update questions
- Remove role and partner labels
- Remove rancher minimum version constraint
- Remove daemonset configuration question for rke tolerations
configuration as nothing seems to be using this value in the previous 
datadog chart (v2.1.2).

