### PR TITLE
Migrate kong v1.8.0

### DIFF
--- a/packages/kong/kong.patch
+++ b/packages/kong/kong.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/kong/charts-original/Chart.yaml packages/kong/charts/Chart.yaml
+--- packages/kong/charts-original/Chart.yaml
++++ packages/kong/charts/Chart.yaml
+@@ -11,3 +11,7 @@
+   name: rainest
+ name: kong
+ version: 1.8.0
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: kong
++  catalog.cattle.io/release-name: kong

--- a/packages/kong/overlay/app-readme.md
+++ b/packages/kong/overlay/app-readme.md
@@ -1,0 +1,7 @@
+# Kong for Kubernetes
+
+[Kong](https://konghq.com) makes connecting APIs and microservices across hybrid or multi-cloud environments easier and faster than ever. We power trillions of API transactions for leading organizations globally through our end-to-end API platform.
+
+Kong Gateway is the world’s most popular open source API gateway, built for multi-cloud and hybrid, and optimized for microservices and distributed architectures.  It is built on top of a lightweight proxy to deliver unparalleled latency, performance and scalability for all your microservice applications regardless of where they run. It allows you to exercise granular control over your traffic with Kong’s plugin architecture
+
+The Kong Enterprise Service Control Platform brokers an organization’s information across all services. Built on top of Kong’s battle-tested open source core, Kong Enterprise enables customers to simplify management of APIs and microservices across hybrid-cloud and multi-cloud deployments. With Kong Enterprise, customers can proactively identify anomalies and threats, automate tasks, and improve visibility across their entire organization.

--- a/packages/kong/overlay/questions.yml
+++ b/packages/kong/overlay/questions.yml
@@ -1,0 +1,11 @@
+labels:
+  io.rancher.certified: partner
+  io.cattle.role: project # options are cluster/project
+categories:
+- API Gateway
+questions:
+- variable: ingressController.installCRDs
+  default: "false"
+  description: "Install CRDs"
+  label: ingressController.installCRDs
+  type: boolean

--- a/packages/kong/overlay/questions.yml
+++ b/packages/kong/overlay/questions.yml
@@ -1,11 +1,6 @@
-labels:
-  io.rancher.certified: partner
-  io.cattle.role: project # options are cluster/project
-categories:
-- API Gateway
 questions:
 - variable: ingressController.installCRDs
-  default: "false"
+  default: false
   description: "Install CRDs"
   label: ingressController.installCRDs
   type: boolean

--- a/packages/kong/package.yaml
+++ b/packages/kong/package.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/Kong/charts/releases/download/kong-1.8.0/kong-1.8.0.tgz
+packageVersion: 00


### PR DESCRIPTION
**NEEDS FIX**
Installing CRDs by enabling the option in questions will result in the following error:
```
Failed to install app kong. Error: rendered manifests contain a resource that already exists. Unable to continue with install: CustomResourceDefinition "kongclusterplugins.configuration.konghq.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "kong"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kong"
```

 Update questions
- Remove role and partner labels
- Remove categories

