### PR TITLE
Migrate harness-delegate

### DIFF
--- a/packages/harness-delegate/harness-delegate.patch
+++ b/packages/harness-delegate/harness-delegate.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/harness-delegate/charts-original/Chart.yaml packages/harness-delegate/charts/Chart.yaml
+--- packages/harness-delegate/charts-original/Chart.yaml
++++ packages/harness-delegate/charts/Chart.yaml
+@@ -12,3 +12,7 @@
+   name: puneet saraswat
+ name: harness-delegate
+ version: 1.0.2
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: harness-delegate
++  catalog.cattle.io/release-name: harness-delegate

--- a/packages/harness-delegate/overlay/app-readme.md
+++ b/packages/harness-delegate/overlay/app-readme.md
@@ -1,0 +1,7 @@
+# Harness Delegate
+
+The [Harness Delegate](https://docs.harness.io/article/de9t8iiynt-harness-architecture) is a service that you run in your local network or VPC to connect Harness Manager with your artifact servers, infrastructure, collaboration providers, and verification providers.
+
+## Introduction
+
+This chart creates a [Harness Delegate](https://docs.harness.io/article/h9tkwmkrm7-delegate-installation) deployment on a [Kubernetes](http://kubernetes.io) cluster, using the [Helm](https://helm.sh) package manager.

--- a/packages/harness-delegate/overlay/questions.yml
+++ b/packages/harness-delegate/overlay/questions.yml
@@ -1,0 +1,134 @@
+categories:
+- CI/CD
+labels:
+  io.rancher.certified: partner
+questions:
+- variable: accountId
+  default: ""
+  description: "Account ID to which the Harness Delegate will connect"
+  type: string
+  required: true
+  label: Account ID
+  group: "Account Details"
+- variable: accountSecret
+  default: ""
+  type: string
+  required: true
+  label: Account Secret
+  group: "Account Details"
+- variable: accountIdShort
+  default: ""
+  description: "6-character identifier for the account"
+  type: string
+  required: true
+  label: Short Account ID
+  group: "Account Details"
+
+# Delegate Configuration
+- variable: delegateName
+  default: "harness-delegate"
+  description: "Name of the Harness Delegate"
+  type: string
+  required: true
+  label: Delegate Name
+  group: "Delegate Configuration"
+- variable: clusterWideRbacScope
+  default: true
+  description: "Role-based access control: Set to True for cluster-wide, or False for namespace-wide"
+  type: boolean
+  required: true
+  label: RBAC scope
+  group: "Delegate Configuration"
+
+# Advanced Server Settings
+- variable: advancedOptions
+  default: false
+  label: Show Advanced Server Configurations
+  type: boolean
+  show_subquestion_if: true
+  group: "Advanced Server Options"
+  subquestions:
+  - variable: managerHostAndPort
+    default: "https://app.harness.io"
+    description: "URL of the Harness server"
+    type: string
+    label: Harness Server  
+  - variable: watcherStorageUrl
+    default: "https://app.harness.io/storage/wingswatchers"
+    type: string
+    label: Watcher Storage URL
+  - variable: watcherCheckLocation
+    default: "watcherprod.txt"
+    description: "Watcher file name"
+    type: string
+    label: Watcher File 
+  - variable: delegateStorageUrl
+    default: "https://app.harness.io/storage/wingsdelegates"
+    type: string
+    label: Delegate Storage URL
+  - variable: delegateCheckLocation
+    default: "delegateprod.txt"
+    description: "Delegate file name"
+    type: string
+    label: Delegate File
+
+  - variable: delegateProfile
+    default: ""
+    description: "ID of the Delegate profile that must run when the Delegate launches"
+    type: string
+    label: Delegate Profile ID
+  - variable: helmDesiredVersion
+    default: ""
+    description: "Helm version to be installed in the Delegate"
+    type: string
+    label: Helm version
+
+# Advanced Proxy Settings
+- variable: advancedProxyOptions
+  default: false
+  label: Show Advanced Proxy Configurations
+  type: boolean
+  show_subquestion_if: true
+  group: "Advanced Proxy Options"
+  subquestions:
+  - variable: proxyManager
+    default: "true"
+    description: "Set to True if the Harness Delegate should go through the proxy"
+    type: boolean
+    label: Proxy Manager
+  - variable: pollForTasks
+    default: "false"
+    description: "Set to True if the proxy does not support WebSocket Protocol (wss)"
+    type: boolean
+    label: Poll For Tasks
+  - variable: proxyHost
+    default: ""
+    description: "URL of the proxy host"
+    type: string
+    label: Proxy Host
+  - variable: proxyPort
+    default: ""
+    type: string
+    label: Proxy Port
+  - variable: proxyUser
+    default: ""
+    type: string
+    label: Proxy Username
+  - variable: proxyPassword
+    default: ""
+    type: string
+    label: Proxy Password
+  - variable: proxyScheme
+    default: ""
+    description: "Select http or https"
+    type: enum
+    label: Proxy Scheme
+    options:
+      - ""
+      - "http"
+      - "https"
+  - variable: noProxy
+    default: ""
+    description: "Enter a comma-separated list of suffixes for which the proxy is not required (.example.com, <specifichost>, ...). Do not insert leading wildcards"
+    type: string
+    label: No Proxy Domains

--- a/packages/harness-delegate/overlay/questions.yml
+++ b/packages/harness-delegate/overlay/questions.yml
@@ -1,7 +1,3 @@
-categories:
-- CI/CD
-labels:
-  io.rancher.certified: partner
 questions:
 - variable: accountId
   default: ""
@@ -31,13 +27,6 @@ questions:
   type: string
   required: true
   label: Delegate Name
-  group: "Delegate Configuration"
-- variable: clusterWideRbacScope
-  default: true
-  description: "Role-based access control: Set to True for cluster-wide, or False for namespace-wide"
-  type: boolean
-  required: true
-  label: RBAC scope
   group: "Delegate Configuration"
 
 # Advanced Server Settings
@@ -92,12 +81,12 @@ questions:
   group: "Advanced Proxy Options"
   subquestions:
   - variable: proxyManager
-    default: "true"
+    default: true
     description: "Set to True if the Harness Delegate should go through the proxy"
     type: boolean
     label: Proxy Manager
   - variable: pollForTasks
-    default: "false"
+    default: false
     description: "Set to True if the proxy does not support WebSocket Protocol (wss)"
     type: boolean
     label: Poll For Tasks

--- a/packages/harness-delegate/package.yaml
+++ b/packages/harness-delegate/package.yaml
@@ -1,0 +1,2 @@
+url: https://app.harness.io/storage/harness-download/harness-helm-charts/harness-delegate-1.0.2.tgz
+packageVersion: 00


### PR DESCRIPTION
**NEEDS FIX**
I can't narrow down what exactly is the problem since it could be from the changes done in their latest upstream chart or the fact I'm testing with a free trial account. 

When installing it using the local Helm 3 cli, it looks like it worked but the pod wont' get past `pending` status. 
When using rancher I get the following error:
```
Failed to install app harness-delegate. Error: rendered manifests contain a resource that already exists. Unable to continue with install: Namespace "harness-delegate" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "harness-delegate"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "harness-delegate"
```
Update questions
- Remove partner label
- Remove categories
- Refactor variables
- Remove cluster RBAC question as it's not available in the
chart values anymore