### PR TITLE
Migrate citrix-k8s-ingress-controller v1.8.28

### DIFF
--- a/packages/citrix-k8s-ingress-controller/citrix-k8s-ingress-controller.patch
+++ b/packages/citrix-k8s-ingress-controller/citrix-k8s-ingress-controller.patch
@@ -1,7 +1,12 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/citrix-k8s-ingress-controller/charts-original/Chart.yaml packages/citrix-k8s-ingress-controller/charts/Chart.yaml
 --- packages/citrix-k8s-ingress-controller/charts-original/Chart.yaml
 +++ packages/citrix-k8s-ingress-controller/charts/Chart.yaml
-@@ -12,3 +12,7 @@
+@@ -8,7 +8,11 @@
+   name: priyankash-citrix
+ - email: subash.dangol@citrix.com
+   name: subashd
+-name: citrix-ingress-controller
++name: citrix-k8s-ingress-controller
  sources:
  - https://github.com/citrix/citrix-k8s-ingress-controller
  version: 1.8.28

--- a/packages/citrix-k8s-ingress-controller/citrix-k8s-ingress-controller.patch
+++ b/packages/citrix-k8s-ingress-controller/citrix-k8s-ingress-controller.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/citrix-k8s-ingress-controller/charts-original/Chart.yaml packages/citrix-k8s-ingress-controller/charts/Chart.yaml
+--- packages/citrix-k8s-ingress-controller/charts-original/Chart.yaml
++++ packages/citrix-k8s-ingress-controller/charts/Chart.yaml
+@@ -12,3 +12,7 @@
+ sources:
+ - https://github.com/citrix/citrix-k8s-ingress-controller
+ version: 1.8.28
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: citrix-k8s-ingress-controller
++  catalog.cattle.io/release-name: citrix-k8s-ingress-controller

--- a/packages/citrix-k8s-ingress-controller/overlay/app-readme.md
+++ b/packages/citrix-k8s-ingress-controller/overlay/app-readme.md
@@ -1,0 +1,5 @@
+# Citrix Ingress Controller
+
+[Citrix Ingress Controler](https://github.com/citrix/citrix-k8s-ingress-controller) is an ingress controller for Citrix ADC MPX (hardware), Citrix ADC VPX (virtualized), and Citrix ADC CPX (containerized) for bare metal and cloud deployments. It is built around Kubernetes Ingress and automatically configures Citrix ADC based on the Ingress resource configuration.
+
+This Chart bootstraps standalone Citrix Ingress Controller which can be used to configure Citrix MPX or VPX.

--- a/packages/citrix-k8s-ingress-controller/overlay/questions.yml
+++ b/packages/citrix-k8s-ingress-controller/overlay/questions.yml
@@ -1,0 +1,146 @@
+labels:
+  io.rancher.certified: partner
+questions:
+- variable: license.accept
+  required: true
+  type: enum
+  description: "Set to yes to accept the terms and conditions of the Citrix license."
+  label: Accept License
+  group: "Deployment Settings"
+  options:
+  - "yes"
+  - "no"
+- variable: openshift
+  default: false
+  type: boolean
+  description: "openshift is set to true if charts are being deployed in OpenShift environment"
+  label: Openshift flag
+  group: "Deployment Settings"
+- variable: loginFileName
+  default: ""
+  type: string
+  description: "loginFileName is secret file for NetScaler login"
+  label: Login File Name
+  group: "Deployment Settings"
+- variable: nsIP
+  required: true
+  type: string
+  description: "nsIP is NetScaler NSIP/SNIP, SNIP in case of HA (mgmt has to be enabled)"
+  label: Citrix ADC IP
+  group: "ADC Settings"
+- variable: nsVIP
+  required: false
+  type: string
+  label: Virtual IP for the clients to connect to
+  group: "ADC Settings"
+- variable: nsPort
+  required: false
+  default: 443
+  type: int
+  description: "nsPort is port for ADC NITRO"
+  label: ADC Port
+  group: "ADC Settings"
+- variable: nsProtocol
+  required: false
+  default: "HTTPS"
+  type: string
+  description: "nsProtocol is protocol for ADC NITRO"
+  label: ADC NITRO protocol
+  group: "ADC Settings"
+- variable: logLevel
+  required: false
+  default: "DEBUG"
+  type: enum
+  label: CIC Loglevel
+  group: "Deployment Settings"
+  options:
+  - "DEBUG"
+  - "INFO"
+  - "WARNING"
+  - "ERROR"
+  - "TRACE"
+- variable: nsNamespace
+  required: false
+  type: string
+  description: "prefix for the resources on the Citrix ADC"
+  label: ADC Entity Prefix
+  group: "ADC Settings"
+- variable: kubernetesURL
+  required: false
+  type: string
+  description: "kubernetesURL is for registering events to kubeapi server"
+  label: Kubernetes API-server URL
+  group: "Deployment Settings"
+- variable: ingressClass[0]
+  required: false
+  type: string
+  description: "ingressClass is the name of the Ingress Class"
+  label: Ingress Class
+  group: "Deployment Settings"
+- variable: defaultSSLCert
+  required: false
+  type: string
+  description: "Secret containing the default ceritifcate for SSL vservers"
+  label: Default SSLCert
+  group: "ADC Settings"
+- variable: nodeWatch
+  required: false
+  default: false
+  type: boolean
+  description: "nodeWatch is used for automatic route configuration on NetScaler towards the pod network"
+  label: NodeWatch
+  group: "ADC Settings"
+- variable: cic.image
+  type: string
+  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.7.6"
+  label: CIC Image
+  group: "CIC Image Settings"
+- variable: cic.pullpolicy
+  default: "Always"
+  type: enum
+  label: CIC Image Pullpolicy
+  group: "CIC Image Settings"
+  options:
+  - "Always"
+  - "IfNotPresent"
+  - "Never"
+- variable: exporter.required
+  default: false
+  type: boolean
+  description: "If set to true exporter will be deployed as sidecar"
+  label: Enable Exporter
+  group: "Exporter Settings"
+- variable: exporter.image
+  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.0"
+  required: false
+  type: string
+  description: "Exporter Image"
+  label: Exporter Image
+  group: "Exporter Settings"
+- variable: exporter.pullPolicy
+  required: false
+  default: Always
+  type: string
+  description: "Exporter Image pull policy"
+  label: Exporter Image PullPolicy
+  group: "Exporter Settings"
+- variable: exporter.ports.containerPort
+  required: false
+  default: 8888 
+  type: int
+  label: Exporter ContainerPort
+  group: "Exporter Settings"
+- variable: crds.install
+  required: false
+  default: true
+  type: boolean
+  description: "If set to true the charts will install CustomResourceDefinitions which are consumed by CIC."
+  label: CRD flag
+  group: "Deployment Settings"
+- variable: crds.retainOnDelete
+  required: false
+  default: false
+  type: boolean
+  description: "Set this argument to true if you want to retain CustomResourceDefinitions even after uninstalling CIC. This will avoid data-loss of Custom Resource Objects created before uninstallation."
+  label: CRD retainOnDelete flag
+  group: "Deployment Settings"

--- a/packages/citrix-k8s-ingress-controller/overlay/questions.yml
+++ b/packages/citrix-k8s-ingress-controller/overlay/questions.yml
@@ -1,5 +1,3 @@
-labels:
-  io.rancher.certified: partner
 questions:
 - variable: license.accept
   required: true
@@ -29,26 +27,22 @@ questions:
   label: Citrix ADC IP
   group: "ADC Settings"
 - variable: nsVIP
-  required: false
   type: string
   label: Virtual IP for the clients to connect to
   group: "ADC Settings"
 - variable: nsPort
-  required: false
   default: 443
   type: int
   description: "nsPort is port for ADC NITRO"
   label: ADC Port
   group: "ADC Settings"
 - variable: nsProtocol
-  required: false
   default: "HTTPS"
   type: string
   description: "nsProtocol is protocol for ADC NITRO"
   label: ADC NITRO protocol
   group: "ADC Settings"
 - variable: logLevel
-  required: false
   default: "DEBUG"
   type: enum
   label: CIC Loglevel
@@ -60,43 +54,38 @@ questions:
   - "ERROR"
   - "TRACE"
 - variable: nsNamespace
-  required: false
   type: string
   description: "prefix for the resources on the Citrix ADC"
   label: ADC Entity Prefix
   group: "ADC Settings"
 - variable: kubernetesURL
-  required: false
   type: string
   description: "kubernetesURL is for registering events to kubeapi server"
   label: Kubernetes API-server URL
   group: "Deployment Settings"
 - variable: ingressClass[0]
-  required: false
   type: string
   description: "ingressClass is the name of the Ingress Class"
   label: Ingress Class
   group: "Deployment Settings"
 - variable: defaultSSLCert
-  required: false
   type: string
   description: "Secret containing the default ceritifcate for SSL vservers"
   label: Default SSLCert
   group: "ADC Settings"
 - variable: nodeWatch
-  required: false
   default: false
   type: boolean
   description: "nodeWatch is used for automatic route configuration on NetScaler towards the pod network"
   label: NodeWatch
   group: "ADC Settings"
-- variable: cic.image
+- variable: image
   type: string
-  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.7.6"
+  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.8.28"
   label: CIC Image
   group: "CIC Image Settings"
-- variable: cic.pullpolicy
-  default: "Always"
+- variable: pullPolicy
+  default: "IfNotPresent"
   type: enum
   label: CIC Image Pullpolicy
   group: "CIC Image Settings"
@@ -111,34 +100,32 @@ questions:
   label: Enable Exporter
   group: "Exporter Settings"
 - variable: exporter.image
-  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.0"
-  required: false
+  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.4"
   type: string
   description: "Exporter Image"
   label: Exporter Image
   group: "Exporter Settings"
 - variable: exporter.pullPolicy
-  required: false
-  default: Always
-  type: string
-  description: "Exporter Image pull policy"
+  default: "IfNotPresent"
+  type: enum
   label: Exporter Image PullPolicy
   group: "Exporter Settings"
+  options:
+  - "Always"
+  - "IfNotPresent"
+  - "Never"
 - variable: exporter.ports.containerPort
-  required: false
   default: 8888 
   type: int
   label: Exporter ContainerPort
   group: "Exporter Settings"
 - variable: crds.install
-  required: false
   default: true
   type: boolean
   description: "If set to true the charts will install CustomResourceDefinitions which are consumed by CIC."
   label: CRD flag
   group: "Deployment Settings"
 - variable: crds.retainOnDelete
-  required: false
   default: false
   type: boolean
   description: "Set this argument to true if you want to retain CustomResourceDefinitions even after uninstalling CIC. This will avoid data-loss of Custom Resource Objects created before uninstallation."

--- a/packages/citrix-k8s-ingress-controller/package.yaml
+++ b/packages/citrix-k8s-ingress-controller/package.yaml
@@ -1,0 +1,2 @@
+url: https://citrix.github.io/citrix-helm-charts/citrix-ingress-controller-1.8.28.tgz
+packageVersion: 00


### PR DESCRIPTION
**UNTESTED:** Requires IP of a Citrix ADC device

Update from `v1.8.19` (old catalog) to `v1.8.28` (Citrix's upstream)
Update chart name to align with name in old catalog
Update questions
- Remove partner label
- Refactor variables
- Update image tags
- Remove unnecessary `required: false`