### PR TITLE
Migrate citrix-api-gateway v1.8.28

### DIFF
--- a/packages/citrix-api-gateway/citrix-api-gateway.patch
+++ b/packages/citrix-api-gateway/citrix-api-gateway.patch
@@ -1,0 +1,63 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/citrix-api-gateway/charts-original/Chart.yaml packages/citrix-api-gateway/charts/Chart.yaml
+--- packages/citrix-api-gateway/charts-original/Chart.yaml
++++ packages/citrix-api-gateway/charts/Chart.yaml
+@@ -12,3 +12,6 @@
+ sources:
+ - https://github.com/citrix/citrix-k8s-ingress-controller
+ version: 1.8.28
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/release-name: citrix-api-gateway
+diff -x '*.tgz' -x '*.lock' -uNr packages/citrix-api-gateway/charts-original/README.md packages/citrix-api-gateway/charts/README.md
+--- packages/citrix-api-gateway/charts-original/README.md
++++ packages/citrix-api-gateway/charts/README.md
+@@ -1,4 +1,9 @@
+-# Citrix Ingress Controller  
++# Citrix API Gateway
++
++[Citrix API Gateway](https://github.com/citrix/citrix-k8s-ingress-controller) is an enterprise-class solution that supports access control, rate limiting and analytics in one integrated system. It can be deployed on-prem, on a private cloud or deployed in a hybrid fashion where its components can be distributed and deployed across multiple cloud and on-prem infrastructures.
++Citrix API GW operator secures APIs and provides a management plane and control plane for managing and monitoring APIs.
++
++This Chart bootstraps standalone Citrix Ingress Controller which can be used to configure Citrix MPX or VPX along with the API Gateway features in the form of CRDs.
+ 
+ [Citrix](https://www.citrix.com/en-in/) provides an Ingress Controller for Citrix ADC MPX (hardware), Citrix ADC VPX (virtualized), and [Citrix ADC CPX](https://docs.citrix.com/en-us/citrix-adc-cpx/13/about.html) (containerized) for [bare metal](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment/baremetal) and [cloud](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment) deployments. It configures one or more Citrix ADC based on the Ingress resource configuration in [Kubernetes](https://kubernetes.io/) or in [OpenShift](https://www.openshift.com) cluster.
+ 
+@@ -221,8 +226,8 @@
+ | Parameters | Mandatory or Optional | Default value | Description |
+ | --------- | --------------------- | ------------- | ----------- |
+ | license.accept | Mandatory | no | Set `yes` to accept the CIC end user license agreement. |
+-| image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.8.28` | The CIC image. |
+-| pullPolicy | Mandatory | IfNotPresent | The CIC image pull policy. |
++| image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.7.46` | The CIC image. |
++| pullPolicy | Mandatory | Always | The CIC image pull policy. |
+ | loginFileName | Mandatory | N/A | The secret key to log on to the Citrix ADC VPX or MPX. For information on how to create the secret keys, see [Prerequisites](#prerequistes). |
+ | nsIP | Mandatory | N/A | The IP address of the Citrix ADC device. For details, see [Prerequisites](#prerequistes). |
+ | nsVIP | Optional | N/A | The Virtual IP address on the Citrix ADC device. |
+@@ -238,25 +243,12 @@
+ | logProxy | Optional | N/A | Provide Elasticsearch or Kafka or Zipkin endpoint for Citrix observability exporter. |
+ | nsNamespace | Optional | k8s | The prefix for the resources on the Citrix ADC VPX/MPX. |
+ | exporter.required | Optional | false | Use the argument, if you want to run the [Exporter for Citrix ADC Stats](https://github.com/citrix/citrix-adc-metrics-exporter) along with CIC to pull metrics for the Citrix ADC VPX or MPX|
+-| exporter.image    | Optional | `quay.io/citrix/citrix-adc-metrics-exporter:1.4.4` | The Exporter image. |
+-| exporter.pullPolicy | Optional | IfNotPresent | The Exporter image pull policy. |
++| exporter.image    | Optional | `quay.io/citrix/citrix-adc-metrics-exporter:1.4.3` | The Exporter image. |
++| exporter.pullPolicy | Optional | Always | The Exporter image pull policy. |
+ | exporter.ports.containerPort | Optional | 8888 | The Exporter container port. |
+ | openshift | Optional | false | Set this argument if OpenShift environment is being used. |
+-| nodeSelector.key | Optional | N/A | Node label key to be used for nodeSelector option in CIC deployment. |
+-| nodeSelector.value | Optional | N/A | Node label value to be used for nodeSelector option in CIC deployment. |
+ | crds.install | Optional | true | Unset this argument if you don't want to install CustomResourceDefinitions which are consumed by CIC. |
+ | crds.retainOnDelete | Optional | false | Set this argument if you want to retain CustomResourceDefinitions even after uninstalling CIC. This will avoid data-loss of Custom Resource Objects created before uninstallation. |
+-| coeConfig.required | Mandatory | false | Set this to true if you want to configure Citrix ADC to send metrics and transaction records to COE. |
+-| coeConfig.distributedTracing.enable | Optional | false | Set this value to true to enable OpenTracing in Citrix ADC. |
+-| coeConfig.distributedTracing.samplingrate | Optional | 100 | Specifies the OpenTracing sampling rate in percentage. |
+-| coeConfig.endpoint.server | Optional | N/A | Set this value as the IP address or DNS address of the  analytics server. |
+-| coeConfig.timeseries.port | Optional | 30002 | Specify the port used to expose COE service outside cluster for timeseries endpoint. |
+-| coeConfig.timeseries.metrics.enable | Optional | Set this value to true to enable sending metrics from Citrix ADC. |
+-| coeConfig.timeseries.metrics.mode | Optional | avro |  Specifies the mode of metric endpoint. |
+-| coeConfig.timeseries.auditlogs.enable | Optional | false | Set this value to true to export audit log data from Citrix ADC. |
+-| coeConfig.timeseries.events.enable | Optional | false | Set this value to true to export events from the Citrix ADC. |
+-| coeConfig.transactions.enable | Optional | false | Set this value to true to export transactions from Citrix ADC. |
+-| coeConfig.transactions.port | Optional | 30001 | Specify the port used to expose COE service outside cluster for transaction endpoint. |
+ 
+ Alternatively, you can define a YAML file with the values for the parameters and pass the values while installing the chart.
+ 

--- a/packages/citrix-api-gateway/overlay/app-readme.md
+++ b/packages/citrix-api-gateway/overlay/app-readme.md
@@ -1,0 +1,6 @@
+# Citrix API Gateway
+
+[Citrix API Gateway](https://github.com/citrix/citrix-k8s-ingress-controller) is an enterprise-class solution that supports access control, rate limiting and analytics in one integrated system. It can be deployed on-prem, on a private cloud or deployed in a hybrid fashion where its components can be distributed and deployed across multiple cloud and on-prem infrastructures.
+Citrix API GW operator secures APIs and provides a management plane and control plane for managing and monitoring APIs.
+
+This Chart bootstraps standalone Citrix Ingress Controller which can be used to configure Citrix MPX or VPX along with the API Gateway features in the form of CRDs.

--- a/packages/citrix-api-gateway/overlay/questions.yml
+++ b/packages/citrix-api-gateway/overlay/questions.yml
@@ -1,0 +1,147 @@
+labels:
+  io.rancher.certified: partner
+questions:
+- variable: license.accept
+  required: true
+  type: enum
+  description: "Set to yes to accept the terms and conditions of the Citrix license."
+  label: Accept License
+  group: "Deployment Settings"
+  options:
+  - "yes"
+  - "no"
+- variable: openshift
+  default: false
+  type: boolean
+  description: "openshift is set to true if charts are being deployed in OpenShift environment"
+  label: Openshift flag
+  group: "Deployment Settings"
+- variable: loginFileName
+  required: true
+  default: ""
+  type: string
+  description: "loginFileName is secret file for NetScaler login"
+  label: Login File Name
+  group: "Deployment Settings"
+- variable: nsIP
+  required: true
+  type: string
+  description: "nsIP is NetScaler NSIP/SNIP, SNIP in case of HA (mgmt has to be enabled)"
+  label: Citrix ADC IP
+  group: "ADC Settings"
+- variable: nsVIP
+  required: false
+  type: string
+  label: Virtual IP for the clients to connect to
+  group: "ADC Settings"
+- variable: nsPort
+  required: false
+  default: 443
+  type: int
+  description: "nsPort is port for ADC NITRO"
+  label: ADC Port
+  group: "ADC Settings"
+- variable: nsProtocol
+  required: false
+  default: "HTTPS"
+  type: string
+  description: "nsProtocol is protocol for ADC NITRO"
+  label: ADC NITRO protocol
+  group: "ADC Settings"
+- variable: logLevel
+  required: false
+  default: "DEBUG"
+  type: enum
+  label: CIC Loglevel
+  group: "Deployment Settings"
+  options:
+  - "DEBUG"
+  - "INFO"
+  - "WARNING"
+  - "ERROR"
+  - "TRACE"
+- variable: nsNamespace
+  required: false
+  type: string
+  description: "prefix for the resources on the Citrix ADC"
+  label: ADC Entity Prefix
+  group: "ADC Settings"
+- variable: kubernetesURL
+  required: false
+  type: string
+  description: "kubernetesURL is for registering events to kubeapi server"
+  label: Kubernetes API-server URL
+  group: "Deployment Settings"
+- variable: ingressClass[0]
+  required: false
+  type: string
+  description: "ingressClass is the name of the Ingress Class"
+  label: Ingress Class
+  group: "Deployment Settings"
+- variable: defaultSSLCert
+  required: false
+  type: string
+  description: "Secret containing the default ceritifcate for SSL vservers"
+  label: Default SSLCert
+  group: "ADC Settings"
+- variable: nodeWatch
+  required: false
+  default: false
+  type: boolean
+  description: "nodeWatch is used for automatic route configuration on NetScaler towards the pod network"
+  label: NodeWatch
+  group: "ADC Settings"
+- variable: cic.image
+  type: string
+  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.8.19"
+  label: CIC Image
+  group: "CIC Image Settings"
+- variable: cic.pullpolicy
+  default: "Always"
+  type: enum
+  label: CIC Image Pullpolicy
+  group: "CIC Image Settings"
+  options:
+  - "Always"
+  - "IfNotPresent"
+  - "Never"
+- variable: exporter.required
+  default: false
+  type: boolean
+  description: "If set to true exporter will be deployed as sidecar"
+  label: Enable Exporter
+  group: "Exporter Settings"
+- variable: exporter.image
+  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.0"
+  required: false
+  type: string
+  description: "Exporter Image"
+  label: Exporter Image
+  group: "Exporter Settings"
+- variable: exporter.pullPolicy
+  required: false
+  default: Always
+  type: string
+  description: "Exporter Image pull policy"
+  label: Exporter Image PullPolicy
+  group: "Exporter Settings"
+- variable: exporter.ports.containerPort
+  required: false
+  default: 8888 
+  type: int
+  label: Exporter ContainerPort
+  group: "Exporter Settings"
+- variable: crds.install
+  required: false
+  default: true
+  type: boolean
+  description: "If set to true the charts will install CustomResourceDefinitions which are consumed by CIC."
+  label: CRD flag
+  group: "Deployment Settings"
+- variable: crds.retainOnDelete
+  required: false
+  default: false
+  type: boolean
+  description: "Set this argument to true if you want to retain CustomResourceDefinitions even after uninstalling CIC. This will avoid data-loss of Custom Resource Objects created before uninstallation."
+  label: CRD retainOnDelete flag
+  group: "Deployment Settings"

--- a/packages/citrix-api-gateway/overlay/questions.yml
+++ b/packages/citrix-api-gateway/overlay/questions.yml
@@ -1,5 +1,3 @@
-labels:
-  io.rancher.certified: partner
 questions:
 - variable: license.accept
   required: true
@@ -30,26 +28,22 @@ questions:
   label: Citrix ADC IP
   group: "ADC Settings"
 - variable: nsVIP
-  required: false
   type: string
   label: Virtual IP for the clients to connect to
   group: "ADC Settings"
 - variable: nsPort
-  required: false
   default: 443
   type: int
   description: "nsPort is port for ADC NITRO"
   label: ADC Port
   group: "ADC Settings"
 - variable: nsProtocol
-  required: false
   default: "HTTPS"
   type: string
   description: "nsProtocol is protocol for ADC NITRO"
   label: ADC NITRO protocol
   group: "ADC Settings"
 - variable: logLevel
-  required: false
   default: "DEBUG"
   type: enum
   label: CIC Loglevel
@@ -61,43 +55,38 @@ questions:
   - "ERROR"
   - "TRACE"
 - variable: nsNamespace
-  required: false
   type: string
   description: "prefix for the resources on the Citrix ADC"
   label: ADC Entity Prefix
   group: "ADC Settings"
 - variable: kubernetesURL
-  required: false
   type: string
   description: "kubernetesURL is for registering events to kubeapi server"
   label: Kubernetes API-server URL
   group: "Deployment Settings"
 - variable: ingressClass[0]
-  required: false
   type: string
   description: "ingressClass is the name of the Ingress Class"
   label: Ingress Class
   group: "Deployment Settings"
 - variable: defaultSSLCert
-  required: false
   type: string
   description: "Secret containing the default ceritifcate for SSL vservers"
   label: Default SSLCert
   group: "ADC Settings"
 - variable: nodeWatch
-  required: false
   default: false
   type: boolean
   description: "nodeWatch is used for automatic route configuration on NetScaler towards the pod network"
   label: NodeWatch
   group: "ADC Settings"
-- variable: cic.image
+- variable: image
   type: string
-  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.8.19"
+  default: "quay.io/citrix/citrix-k8s-ingress-controller:1.8.28"
   label: CIC Image
   group: "CIC Image Settings"
-- variable: cic.pullpolicy
-  default: "Always"
+- variable: pullPolicy
+  default: "IfNotPresent"
   type: enum
   label: CIC Image Pullpolicy
   group: "CIC Image Settings"
@@ -112,34 +101,32 @@ questions:
   label: Enable Exporter
   group: "Exporter Settings"
 - variable: exporter.image
-  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.0"
-  required: false
+  default: "quay.io/citrix/citrix-adc-metrics-exporter:1.4.4"
   type: string
   description: "Exporter Image"
   label: Exporter Image
   group: "Exporter Settings"
 - variable: exporter.pullPolicy
-  required: false
-  default: Always
-  type: string
-  description: "Exporter Image pull policy"
+  default: "IfNotPresent"
+  type: enum
   label: Exporter Image PullPolicy
   group: "Exporter Settings"
+  options:
+  - "Always"
+  - "IfNotPresent"
+  - "Never"
 - variable: exporter.ports.containerPort
-  required: false
   default: 8888 
   type: int
   label: Exporter ContainerPort
   group: "Exporter Settings"
 - variable: crds.install
-  required: false
   default: true
   type: boolean
   description: "If set to true the charts will install CustomResourceDefinitions which are consumed by CIC."
   label: CRD flag
   group: "Deployment Settings"
 - variable: crds.retainOnDelete
-  required: false
   default: false
   type: boolean
   description: "Set this argument to true if you want to retain CustomResourceDefinitions even after uninstalling CIC. This will avoid data-loss of Custom Resource Objects created before uninstallation."

--- a/packages/citrix-api-gateway/package.yaml
+++ b/packages/citrix-api-gateway/package.yaml
@@ -1,0 +1,2 @@
+url: https://citrix.github.io/citrix-helm-charts/citrix-ingress-controller-1.8.28.tgz
+packageVersion: 00


### PR DESCRIPTION
**UNTESTED:** Requires IP of a Citrix ADC device

This chart shares the same upstream as `citrix-ingress-controller` reviewed here: https://github.com/rancher/partner-charts/pull/37

Update questions
-Remove partner label
-Refactor variables
-Update image tags
-Remove unnecessary required: false
