### PR TITLE
Migrate hpe flexvolume driver

### DIFF
--- a/packages/hpe-flexvolume-driver/hpe-flexvolume-driver.patch
+++ b/packages/hpe-flexvolume-driver/hpe-flexvolume-driver.patch
@@ -1,0 +1,11 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/hpe-flexvolume-driver/charts-original/Chart.yaml packages/hpe-flexvolume-driver/charts/Chart.yaml
+--- packages/hpe-flexvolume-driver/charts-original/Chart.yaml
++++ packages/hpe-flexvolume-driver/charts/Chart.yaml
+@@ -18,3 +18,7 @@
+ sources:
+ - https://github.com/hpe-storage/flexvolume-driver
+ version: 3.1.0
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/namespace: hpe-flexvolume-driver
++  catalog.cattle.io/release-name: hpe-flexvolume-driver

--- a/packages/hpe-flexvolume-driver/hpe-flexvolume-driver.patch
+++ b/packages/hpe-flexvolume-driver/hpe-flexvolume-driver.patch
@@ -9,3 +9,194 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/hpe-flexvolume-driver/charts-original/
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/namespace: hpe-flexvolume-driver
 +  catalog.cattle.io/release-name: hpe-flexvolume-driver
+diff -x '*.tgz' -x '*.lock' -uNr packages/hpe-flexvolume-driver/charts-original/app-readme.md packages/hpe-flexvolume-driver/charts/app-readme.md
+--- packages/hpe-flexvolume-driver/charts-original/app-readme.md
++++ packages/hpe-flexvolume-driver/charts/app-readme.md
+@@ -1,3 +0,0 @@
+-# HPE Volume Driver for Kubernetes FlexVolume Plugin
+-
+-The [HPE Volume Driver for Kubernetes FlexVolume plugin](https://github.com/hpe-storage/flexvolume-driver) leverages HPE storage platforms to provide scalable and persistent storage for stateful applications. This chart also deploys the [HPE Dynamic Provisioner for Kubernetes](https://github.com/hpe-storage/k8s-dynamic-provisioner).
+diff -x '*.tgz' -x '*.lock' -uNr packages/hpe-flexvolume-driver/charts-original/questions.yml packages/hpe-flexvolume-driver/charts/questions.yml
+--- packages/hpe-flexvolume-driver/charts-original/questions.yml
++++ packages/hpe-flexvolume-driver/charts/questions.yml
+@@ -1,179 +0,0 @@
+-categories:
+-- storage
+-namespace: kube-system
+-rancher_min_version: 2.2.0
+-labels:
+-  io.cattle.role: cluster
+-  io.rancher.certified: partner
+-questions:
+-- variable: flavor
+-  label: "Kubernetes flavor"
+-  type: enum
+-  default: "rke"
+-  required: true
+-  options:
+-    - "rke"
+-    - "eks"
+-    - "ocp"
+-    - "aks"
+-    - "gke"
+-    - "gkeop"
+-    - "k8s"
+-  description: "Tweak Helm chart behavior."
+-  group: "Rancher specific settings"
+-- variable: pluginType
+-  label: "HPE platform"
+-  type: enum
+-  options:
+-    - "nimble"
+-    - "cv"
+-    - "simplivity"
+-  default: "nimble"
+-  description: "HPE platform type for the deployment."
+-  group: "HPE backend settings"
+-- variable: backend
+-  label: "IP address"
+-  type: string
+-  required: true
+-  description: "Please specify HPE backend IP address."
+-  group: "HPE backend settings"
+-- variable: username
+-  label: "Username"
+-  type: string
+-  required: true
+-  description: "Specify username with backend storage admin permissions."
+-  group: "HPE backend settings"
+-- variable: password
+-  label: "Password"
+-  type: password
+-  required: true
+-  description: "Specify password for the backend user."
+-  group: "HPE backend settings"
+-- variable: fsType
+-  label: "Filesystem"
+-  default: "xfs"
+-  type: enum
+-  options:
+-    - "xfs"
+-    - "ext4"
+-    - "ext3"
+-    - "btrfs"
+-  description: "Select the filesystem for Persistent Volumes, defaults to xfs."
+-  group: "HPE StorageClass and volume settings"
+-- variable: protocol
+-  label: "HPE storage protocol"
+-  type: enum
+-  default: "iscsi"
+-  options:
+-    - "iscsi"
+-    - "fc"
+-  description: "Specify storage protocol for HPE backend connectivity."
+-  group: "HPE StorageClass and volume settings"
+-- variable: storageClass.create
+-  label: "Create a StorageClass"
+-  type: boolean
+-  default: true
+-  required: true
+-  description: "If specified as 'true', a StorageClass named 'hpe-standard' will be created with the HPE Volume Driver for Kubernetes FlexVolume Plugin as provisioner."
+-  group: "HPE StorageClass and volume settings"
+-- variable: storageClass.defaultClass
+-  label: "Mark StorageClass 'hpe-standard' as 'default'."
+-  type: boolean
+-  default: false
+-  description: "If specified as 'true', the 'hpe-standard' StorageClass will be annotated as 'default'. This option is ignored if 'Create a StorageClass' is set to 'false'."
+-  group: "HPE StorageClass and volume settings"
+-- variable: cv.config.existingCloudSubnet
+-  show_if: "pluginType=cv"
+-  label: "Cloud subnet"
+-  type: string
+-  default: ""
+-  required: true
+-  description: "Cloud subnet of the cluster for connection provisioning"
+-  group: "Cloud instance settings"
+-- variable: cv.config.privateCloud
+-  show_if: "pluginType=cv"
+-  label: "Virtual private cloud"
+-  type: string
+-  required: true
+-  description: "Virtual private cloud of the cluster"
+-  group: "Cloud instance settings"
+-- variable: cv.config.region
+-  show_if: "pluginType=cv"
+-  label: "Public cloud region"
+-  type: string
+-  required: true
+-  description: "Public cloud provider region in which cluster resides"
+-  group: "Cloud instance settings"
+-- variable: cv.config.cloudComputeProvider
+-  show_if: "pluginType=cv"
+-  label: "Public cloud provider"
+-  type: enum
+-  default: "Amazon AWS"
+-  options:
+-    - "Amazon AWS"
+-    - "Microsoft Azure"
+-  description: "Public cloud provider name"
+-  group: "Cloud instance settings"
+-- variable: cv.config.privateCloudResourceGroup
+-  show_if: "cv.config.cloudComputeProvider=Microsoft Azure"
+-  label: "Azure Resource Group"
+-  type: string
+-  required: true
+-  description: "Azure resource group for the cluster"
+-  group: "Cloud instance settings"
+-- variable: cv.config.volumeType
+-  show_if: "pluginType=cv"
+-  label: "Volume type"
+-  type: enum
+-  default: "PF"
+-  options:
+-    - "PF"
+-    - "GPF"
+-  description: "HPE Cloud Volume type"
+-  group: "HPE Cloud Volumes settings"
+-- variable: cv.config.encryption
+-  show_if: "pluginType=cv"
+-  label: "Volume Encryption"
+-  type: boolean
+-  default: true
+-  required: true
+-  description: "Encryption for HPE Cloud Volume"
+-  group: "HPE Cloud Volumes settings"
+-- variable: cv.config.protectionTemplate
+-  show_if: "pluginType=cv"
+-  label: "Protection template"
+-  type: enum
+-  default: "twicedaily:4"
+-  options:
+-    - "daily:3"
+-    - "daily:7"
+-    - "daily:14"
+-    - "hourly:6"
+-    - "hourly:12"
+-    - "hourly:24"
+-    - "twicedaily:4"
+-    - "twicedaily:8"
+-    - "twicedaily:14"
+-    - "weekly:2"
+-    - "weekly:4"
+-    - "weekly:8"
+-    - "monthly:3"
+-    - "monthly:6"
+-    - "monthly:12"
+-    - "none"
+-  description: "Protection Template"
+-  group: "HPE Cloud Volumes settings"
+-- variable: cv.config.perfPolicy
+-  show_if: "pluginType=cv"
+-  label: "Performance policy"
+-  type: enum
+-  default: "Other"
+-  options:
+-    - "Other"
+-    - "Exchange"
+-    - "Oracle"
+-    - "SharePoint"
+-    - "SQL"
+-    - "Windows File Server"
+-  description: "Performance policy"
+-  group: "HPE Cloud Volumes settings"
+\ No newline at end of file

--- a/packages/hpe-flexvolume-driver/overlay/app-readme.md
+++ b/packages/hpe-flexvolume-driver/overlay/app-readme.md
@@ -1,0 +1,3 @@
+# HPE Volume Driver for Kubernetes FlexVolume Plugin
+
+The [HPE Volume Driver for Kubernetes FlexVolume plugin](https://github.com/hpe-storage/flexvolume-driver) leverages HPE storage platforms to provide scalable and persistent storage for stateful applications. This chart also deploys the [HPE Dynamic Provisioner for Kubernetes](https://github.com/hpe-storage/k8s-dynamic-provisioner).

--- a/packages/hpe-flexvolume-driver/overlay/questions.yml
+++ b/packages/hpe-flexvolume-driver/overlay/questions.yml
@@ -1,0 +1,179 @@
+categories:
+- storage
+namespace: kube-system
+rancher_min_version: 2.2.0
+labels:
+  io.cattle.role: cluster
+  io.rancher.certified: partner
+questions:
+- variable: flavor
+  label: "Kubernetes flavor"
+  type: enum
+  default: "rke"
+  required: true
+  options:
+    - "rke"
+    - "eks"
+    - "ocp"
+    - "aks"
+    - "gke"
+    - "gkeop"
+    - "k8s"
+  description: "Tweak Helm chart behavior."
+  group: "Rancher specific settings"
+- variable: pluginType
+  label: "HPE platform"
+  type: enum
+  options:
+    - "nimble"
+    - "cv"
+    - "simplivity"
+  default: "nimble"
+  description: "HPE platform type for the deployment."
+  group: "HPE backend settings"
+- variable: backend
+  label: "IP address"
+  type: string
+  required: true
+  description: "Please specify HPE backend IP address."
+  group: "HPE backend settings"
+- variable: username
+  label: "Username"
+  type: string
+  required: true
+  description: "Specify username with backend storage admin permissions."
+  group: "HPE backend settings"
+- variable: password
+  label: "Password"
+  type: password
+  required: true
+  description: "Specify password for the backend user."
+  group: "HPE backend settings"
+- variable: fsType
+  label: "Filesystem"
+  default: "xfs"
+  type: enum
+  options:
+    - "xfs"
+    - "ext4"
+    - "ext3"
+    - "btrfs"
+  description: "Select the filesystem for Persistent Volumes, defaults to xfs."
+  group: "HPE StorageClass and volume settings"
+- variable: protocol
+  label: "HPE storage protocol"
+  type: enum
+  default: "iscsi"
+  options:
+    - "iscsi"
+    - "fc"
+  description: "Specify storage protocol for HPE backend connectivity."
+  group: "HPE StorageClass and volume settings"
+- variable: storageClass.create
+  label: "Create a StorageClass"
+  type: boolean
+  default: true
+  required: true
+  description: "If specified as 'true', a StorageClass named 'hpe-standard' will be created with the HPE Volume Driver for Kubernetes FlexVolume Plugin as provisioner."
+  group: "HPE StorageClass and volume settings"
+- variable: storageClass.defaultClass
+  label: "Mark StorageClass 'hpe-standard' as 'default'."
+  type: boolean
+  default: false
+  description: "If specified as 'true', the 'hpe-standard' StorageClass will be annotated as 'default'. This option is ignored if 'Create a StorageClass' is set to 'false'."
+  group: "HPE StorageClass and volume settings"
+- variable: cv.config.existingCloudSubnet
+  show_if: "pluginType=cv"
+  label: "Cloud subnet"
+  type: string
+  default: ""
+  required: true
+  description: "Cloud subnet of the cluster for connection provisioning"
+  group: "Cloud instance settings"
+- variable: cv.config.privateCloud
+  show_if: "pluginType=cv"
+  label: "Virtual private cloud"
+  type: string
+  required: true
+  description: "Virtual private cloud of the cluster"
+  group: "Cloud instance settings"
+- variable: cv.config.region
+  show_if: "pluginType=cv"
+  label: "Public cloud region"
+  type: string
+  required: true
+  description: "Public cloud provider region in which cluster resides"
+  group: "Cloud instance settings"
+- variable: cv.config.cloudComputeProvider
+  show_if: "pluginType=cv"
+  label: "Public cloud provider"
+  type: enum
+  default: "Amazon AWS"
+  options:
+    - "Amazon AWS"
+    - "Microsoft Azure"
+  description: "Public cloud provider name"
+  group: "Cloud instance settings"
+- variable: cv.config.privateCloudResourceGroup
+  show_if: "cv.config.cloudComputeProvider=Microsoft Azure"
+  label: "Azure Resource Group"
+  type: string
+  required: true
+  description: "Azure resource group for the cluster"
+  group: "Cloud instance settings"
+- variable: cv.config.volumeType
+  show_if: "pluginType=cv"
+  label: "Volume type"
+  type: enum
+  default: "PF"
+  options:
+    - "PF"
+    - "GPF"
+  description: "HPE Cloud Volume type"
+  group: "HPE Cloud Volumes settings"
+- variable: cv.config.encryption
+  show_if: "pluginType=cv"
+  label: "Volume Encryption"
+  type: boolean
+  default: true
+  required: true
+  description: "Encryption for HPE Cloud Volume"
+  group: "HPE Cloud Volumes settings"
+- variable: cv.config.protectionTemplate
+  show_if: "pluginType=cv"
+  label: "Protection template"
+  type: enum
+  default: "twicedaily:4"
+  options:
+    - "daily:3"
+    - "daily:7"
+    - "daily:14"
+    - "hourly:6"
+    - "hourly:12"
+    - "hourly:24"
+    - "twicedaily:4"
+    - "twicedaily:8"
+    - "twicedaily:14"
+    - "weekly:2"
+    - "weekly:4"
+    - "weekly:8"
+    - "monthly:3"
+    - "monthly:6"
+    - "monthly:12"
+    - "none"
+  description: "Protection Template"
+  group: "HPE Cloud Volumes settings"
+- variable: cv.config.perfPolicy
+  show_if: "pluginType=cv"
+  label: "Performance policy"
+  type: enum
+  default: "Other"
+  options:
+    - "Other"
+    - "Exchange"
+    - "Oracle"
+    - "SharePoint"
+    - "SQL"
+    - "Windows File Server"
+  description: "Performance policy"
+  group: "HPE Cloud Volumes settings"

--- a/packages/hpe-flexvolume-driver/overlay/questions.yml
+++ b/packages/hpe-flexvolume-driver/overlay/questions.yml
@@ -1,10 +1,3 @@
-categories:
-- storage
-namespace: kube-system
-rancher_min_version: 2.2.0
-labels:
-  io.cattle.role: cluster
-  io.rancher.certified: partner
 questions:
 - variable: flavor
   label: "Kubernetes flavor"

--- a/packages/hpe-flexvolume-driver/package.yaml
+++ b/packages/hpe-flexvolume-driver/package.yaml
@@ -1,0 +1,2 @@
+url: https://hpe-storage.github.io/co-deployments/hpe-flexvolume-driver-3.1.0.tgz
+packageVersion: 00


### PR DESCRIPTION
**UNTESTED:** 
An HPE Cloud Volumes account or HPE Numble Storage array is needed to install this chart. No significant changes were done to the chart itself so it should be safe. The only significant change was removing the lock to installing in the kube-system namespace only in questions.yaml, but the partner confirmed installation in the kube-system namespace is not required.

Move app-readme and questions to overlay
Update questions
- Remove categories
- Remove role and partner labels
- Remove hardcoded namespace set to `kube-system`
- Remove rancher minimum version constraint