### PR TITLE
[dev-v2.5] move to main as primary branch

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,7 +2,7 @@ name: CI-pullrequest
 
 on:
   pull_request:
-    branches: [ dev-v2.5 ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: CI-push
 
 on:
   push:
-    branches: [ dev-v2.5 ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Pushing into 2.5 branch is necessary so that build doesn't overwrite the main one

Rancher PR merge: https://github.com/rancher/rancher/pull/28778