### PR TITLE
Use for loop to run CI per charts

### DIFF
--- a/scripts/ci-wrapper
+++ b/scripts/ci-wrapper
@@ -11,6 +11,7 @@ git checkout origin/${1} ./sha256sum || true
 
 charts=$(./scripts/produce-sha256)
 
-if [[ -n ${charts} ]]; then
-  echo $charts | xargs ./scripts/ci
-fi
+# produce-sha256 produces sha256 and print out chart name that has changed, and only run CI against changed chart
+for i in $(./scripts/produce-sha256); do
+    ./scripts/ci $i
+done


### PR DESCRIPTION
Grabbing changes from https://github.com/rancher/charts/pull/695 to fix CI.

Dependent on merge:
- [x] Regenerate sha256sum (https://github.com/rancher/partner-charts/pull/42)

Related Issue: https://github.com/rancher/rancher/issues/29121