### PR TITLE
Only call produce-sha256 once

### DIFF
--- a/scripts/ci-wrapper
+++ b/scripts/ci-wrapper
@@ -9,8 +9,6 @@ git fetch origin ${1}
 git checkout origin/${1} ./assets/index.yaml || true
 git checkout origin/${1} ./sha256sum || true
 
-charts=$(./scripts/produce-sha256)
-
 # produce-sha256 produces sha256 and print out chart name that has changed, and only run CI against changed chart
 for i in $(./scripts/produce-sha256); do
     ./scripts/ci $i


### PR DESCRIPTION
Fixes https://github.com/rancher/partner-charts/pull/41 by only calling produce-sha256 once.

Dependent on merge:
- [ ] Regenerate hashes try #2 (https://github.com/rancher/partner-charts/pull/43)

Related Issue: https://github.com/rancher/rancher/issues/29121