### PR TITLE
Ignore charts directory for Github Pages build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+exclude: [charts]


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/31021

#### Why is this needed?

Currently, we serve URLs like http://partner-charts.rancher.io/charts/artifactory-ha/ but there's no need for us to do that. This PR explicitly excludes that directory from being served due to issues it caused with Jekyll trying to interpret the files to dynamically serve the content.

#### How did you catch this?

Pull in the scripts locally, install Jekyll, and run `jekyll serve --trace`. You'll see:

`Liquid Exception: Liquid error (line 13): wrong number of arguments (given 1, expected 2..3) in charts/kubecost/charts/thanos/templates/query-frontend-ingress.yml`

Adding kubecost is exactly when our builds started to fail, but I think the fix should be on our end, not for the chart to be modified.