### PR TITLE
Update haproxy chart to latest release

### DIFF
--- a/packages/haproxy/haproxy.patch
+++ b/packages/haproxy/haproxy.patch
@@ -9,7 +9,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/haproxy/charts-original/Chart.yaml pac
 +name: haproxy
  sources:
  - https://github.com/haproxytech/kubernetes-ingress
- version: 1.4.3
+ version: 1.12.1
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: haproxy

--- a/packages/haproxy/package.yaml
+++ b/packages/haproxy/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.4.3/kubernetes-ingress-1.4.3.tgz
+url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.12.1/kubernetes-ingress-1.12.1.tgz
 packageVersion: 00


### PR DESCRIPTION
This PR updates the HAProxy ingress controller from 1.43 to 1.12.1