### PR TITLE
Updating the cloudcasa version to 1.0

### DIFF
--- a/packages/cloudcasa/cloudcasa.patch
+++ b/packages/cloudcasa/cloudcasa.patch
@@ -2,7 +2,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/cloudcasa/charts-original/Chart.yaml p
 --- packages/cloudcasa/charts-original/Chart.yaml
 +++ packages/cloudcasa/charts/Chart.yaml
 @@ -2,7 +2,7 @@
- appVersion: 0.1.0
+ appVersion: "1.0"
  description: CloudCasa backup service for Kubernetes and cloud native applications
  home: https://cloudcasa.io
 -icon: file://../logo.png
@@ -13,7 +13,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/cloudcasa/charts-original/Chart.yaml p
 @@ -13,3 +13,7 @@
    name: catalogicsoftware
  name: cloudcasa
- version: 0.1.0
+ version: "1.0"
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: cloudcasa

--- a/packages/cloudcasa/package.yaml
+++ b/packages/cloudcasa/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/catalogicsoftware/cloudcasa-helmchart/releases/download/cloudcasa-0.1.0/cloudcasa-0.1.0.tgz 
+url: https://github.com/catalogicsoftware/cloudcasa-helmchart/releases/download/cloudcasa-1.0/cloudcasa-1.0.tgz 
 packageVersion: 00


### PR DESCRIPTION
Here we are pushing CloudCasa production release v1.0 to Rancher partner charts.