### PR TITLE
Update HAProxy Ingress to 1.12.5

### DIFF
--- a/packages/haproxy/haproxy.patch
+++ b/packages/haproxy/haproxy.patch
@@ -9,7 +9,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/haproxy/charts-original/Chart.yaml pac
 +name: haproxy
  sources:
  - https://github.com/haproxytech/kubernetes-ingress
- version: 1.12.1
+ version: 1.12.5
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: haproxy

--- a/packages/haproxy/overlay/questions.yml
+++ b/packages/haproxy/overlay/questions.yml
@@ -8,7 +8,7 @@ questions:
   show_subquestion_if: false
   subquestions:
   - variable: controller.image.tag
-    default: "1.4.6"
+    default: "1.5.4"
     description: "HAProxy Ingress Controller Tag"
     type: string
     label: HAProxy Ingress Controller Tag

--- a/packages/haproxy/package.yaml
+++ b/packages/haproxy/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.12.1/kubernetes-ingress-1.12.1.tgz
+url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.12.5/kubernetes-ingress-1.12.5.tgz
 packageVersion: 00


### PR DESCRIPTION
This is a minor update to the HAProxy Ingress controller chart