### PR TITLE
k8s-triliovault-operator release update v2.0.5

### DIFF
--- a/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
+++ b/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
@@ -4,7 +4,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/k8s-triliovault-operator/charts-origin
 @@ -10,3 +10,6 @@
  sources:
  - https://github.com/trilioData/k8s-triliovault-operator
- version: v2.0.2
+ version: v2.0.5
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: k8s-triliovault-operator

--- a/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
+++ b/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
@@ -1,10 +1,59 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/k8s-triliovault-operator/charts-original/Chart.yaml packages/k8s-triliovault-operator/charts/Chart.yaml
 --- packages/k8s-triliovault-operator/charts-original/Chart.yaml
 +++ packages/k8s-triliovault-operator/charts/Chart.yaml
-@@ -10,3 +10,6 @@
+@@ -1,6 +1,7 @@
+ apiVersion: v1
+ appVersion: v2.0.5
+-description: K8s-TrilioVault-Operator is an operator designed to manage the K8s-TrilioVault Application Lifecycle.
++description: K8s-TrilioVault-Operator is an operator designed to manage the K8s-TrilioVault
++  Application Lifecycle.
+ home: https://github.com/trilioData/k8s-triliovault-operator
+ icon: https://www.trilio.io/wp-content/uploads/2021/01/Trilio-2020-logo-RGB-gray-green.png
+ maintainers:
+@@ -9,4 +10,4 @@
+ name: k8s-triliovault-operator
  sources:
  - https://github.com/trilioData/k8s-triliovault-operator
- version: v2.0.5
-+annotations:
-+  catalog.cattle.io/certified: partner
-+  catalog.cattle.io/release-name: k8s-triliovault-operator
+-version: v2.0.5
++version: v2.0.500
+diff -x '*.tgz' -x '*.lock' -uNr packages/k8s-triliovault-operator/charts-original/app-readme.md packages/k8s-triliovault-operator/charts/app-readme.md
+--- packages/k8s-triliovault-operator/charts-original/app-readme.md
++++ packages/k8s-triliovault-operator/charts/app-readme.md
+@@ -0,0 +1,37 @@
++# TrilioVault for Kubernetes
++
++[K8s-TrilioVault-Operator](https://trilio.io) is an operator designed to manage
++the K8s-TrilioVault Application Lifecycle.
++
++This operator is to manage the lifecycle of TrilioVault Backup/Recovery solution. This operator install, updates and manage the TrilioVault application.
++
++Introduction:
++
++Prerequisites:
++
++Kubernetes 1.17+
++Alpha feature gates should be enabled
++PV provisioner support
++CSI driver should be installed
++
++Installation:
++
++To install the chart with the operator name trilio:
++
++helm install k8s-triliovault-operator triliovault-operator/k8s-triliovault-operator
++
++# For helm version 3
++
++helm install triliovault-operator triliovault-operator/k8s-triliovault-operator
++
++The command deploys the Triliovault for Kubernetes Operator with the default configuration.
++
++Uninstall:
++
++To uninstall/delete the chart trilio :
++
++# For helm version 3
++helm uninstall k8s-triliovault-operator
++
++For more information around TVM manager installation, please follow below link:
++https://docs.trilio.io/kubernetes/use-triliovault/installing-triliovault

--- a/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
+++ b/packages/k8s-triliovault-operator/k8s-triliovault-operator.patch
@@ -10,12 +10,16 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/k8s-triliovault-operator/charts-origin
  home: https://github.com/trilioData/k8s-triliovault-operator
  icon: https://www.trilio.io/wp-content/uploads/2021/01/Trilio-2020-logo-RGB-gray-green.png
  maintainers:
-@@ -9,4 +10,4 @@
+@@ -9,4 +10,8 @@
  name: k8s-triliovault-operator
  sources:
  - https://github.com/trilioData/k8s-triliovault-operator
 -version: v2.0.5
-+version: v2.0.500
++version: 2.0.5
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/release-name: k8s-triliovault-operator
++  catalog.cattle.io/display-name: TrilioVault for Kubernetes Operator
 diff -x '*.tgz' -x '*.lock' -uNr packages/k8s-triliovault-operator/charts-original/app-readme.md packages/k8s-triliovault-operator/charts/app-readme.md
 --- packages/k8s-triliovault-operator/charts-original/app-readme.md
 +++ packages/k8s-triliovault-operator/charts/app-readme.md

--- a/packages/k8s-triliovault-operator/overlay/app-readme.md
+++ b/packages/k8s-triliovault-operator/overlay/app-readme.md
@@ -1,4 +1,4 @@
 # TrilioVault for Kubernetes
 
-[K8s-TrilioVault-Operator](https://trilio.io) is an operator designed to manage the K8s-TrilioVault Application 
-Lifecycle.
+[K8s-TrilioVault-Operator](https://trilio.io) is an operator designed to manage
+the K8s-TrilioVault Application Lifecycle.

--- a/packages/k8s-triliovault-operator/overlay/app-readme.md
+++ b/packages/k8s-triliovault-operator/overlay/app-readme.md
@@ -2,3 +2,36 @@
 
 [K8s-TrilioVault-Operator](https://trilio.io) is an operator designed to manage
 the K8s-TrilioVault Application Lifecycle.
+
+This operator is to manage the lifecycle of TrilioVault Backup/Recovery solution. This operator install, updates and manage the TrilioVault application.
+
+Introduction:
+
+Prerequisites:
+
+Kubernetes 1.17+
+Alpha feature gates should be enabled
+PV provisioner support
+CSI driver should be installed
+
+Installation:
+
+To install the chart with the operator name trilio:
+
+helm install k8s-triliovault-operator triliovault-operator/k8s-triliovault-operator
+
+# For helm version 3
+
+helm install triliovault-operator triliovault-operator/k8s-triliovault-operator
+
+The command deploys the Triliovault for Kubernetes Operator with the default configuration.
+
+Uninstall:
+
+To uninstall/delete the chart trilio :
+
+# For helm version 3
+helm uninstall k8s-triliovault-operator
+
+For more information around TVM manager installation, please follow below link:
+https://docs.trilio.io/kubernetes/use-triliovault/installing-triliovault

--- a/packages/k8s-triliovault-operator/package.yaml
+++ b/packages/k8s-triliovault-operator/package.yaml
@@ -1,2 +1,2 @@
-url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-v2.0.2.tgz
+url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-v2.0.5.tgz
 packageVersion: 00


### PR DESCRIPTION
This pull request contains:

1. New helm package update for k8s-triliovault-operator v2.0.5
2. Updated readme.md file to have 80 chars in single line