### PR TITLE
Add Ambassador Edge Stack to Rancher's partner charts

### DIFF
--- a/packages/ambassador/ambassador.patch
+++ b/packages/ambassador/ambassador.patch
@@ -1,0 +1,10 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/ambassador/charts-original/Chart.yaml packages/ambassador/charts/Chart.yaml
+--- packages/ambassador/charts-original/Chart.yaml
++++ packages/ambassador/charts/Chart.yaml
+@@ -1,3 +1,6 @@
++annotations:
++  catalog.cattle.io/certified: partner
++  catalog.cattle.io/release-name: ambassador
+ apiVersion: v1
+ appVersion: 1.13.6
+ description: A Helm chart for Datawire Ambassador

--- a/packages/ambassador/ambassador.patch
+++ b/packages/ambassador/ambassador.patch
@@ -1,10 +1,11 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/ambassador/charts-original/Chart.yaml packages/ambassador/charts/Chart.yaml
 --- packages/ambassador/charts-original/Chart.yaml
 +++ packages/ambassador/charts/Chart.yaml
-@@ -1,3 +1,6 @@
+@@ -1,3 +1,7 @@
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: ambassador
++  catalog.cattle.io/display-name: Ambassador Edge Stack
  apiVersion: v1
- appVersion: 1.13.6
+ appVersion: 1.13.8
  description: A Helm chart for Datawire Ambassador

--- a/packages/ambassador/overlay/app-readme.md
+++ b/packages/ambassador/overlay/app-readme.md
@@ -1,0 +1,13 @@
+# Ambassador Edge Stack and Emissary Ingress Chart
+
+[Ambassador Edge Stack](https://www.getambassador.io/products/edge-stack/) and its open source CNCF counterpart [Emissary-Ingress](https://www.getambassador.io/products/api-gateway/) are Kubernetes native, high-performance Ingress controllers designed with GitOps workflows and developer experience in mind.  The Edge Stack allows users to manage [Authentication](https://www.getambassador.io/docs/edge-stack/latest/topics/using/filters/), [Rate Limits](https://www.getambassador.io/docs/edge-stack/latest/topics/using/rate-limits/rate-limits/), [TLS](https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/) and more with easy-to-use resources for [managing your APIs](https://www.getambassador.io/docs/edge-stack/latest/topics/using/intro-mappings/).
+
+## Service Catalog
+
+The default installation of Ambassador Edge Stack includes the deployment needed to get started with [Service Catalog](https://www.getambassador.io/products/service-catalog/) and the [Developer Control Plane](https://www.getambassador.io/developer-control-plane/).  Simply generate your [Cloud Token](https://www.getambassador.io/docs/cloud/latest/service-catalog/quick-start/#1-connect-your-cluster-to-ambassador-cloud) and add it in the Service Catalog section as you're setting up the chart.
+
+## More Info
+
+Visit the [Quick Start](https://www.getambassador.io/docs/edge-stack/latest/tutorials/getting-started/) page for more instructions, or check out our [documentation](https://www.getambassador.io/docs/edge-stack).  For any questions, or to join the community, visit our [Slack](https://a8r.io/slack) and say hi!
+
+* Ambassador recommends a Kubernetes version of 1.16 or higher.

--- a/packages/ambassador/overlay/questions.yml
+++ b/packages/ambassador/overlay/questions.yml
@@ -1,0 +1,84 @@
+questions:
+### CRD Management
+- variable: crds.enabled
+  label: Create CRDs
+  description: "Should Ambassador Edge Stack create and manage its CRD's?"
+  type: boolean
+  required: false
+  default: "true"
+  group: "CRD Management"
+- variable: crds.keep
+  label: Keep CRDs
+  description: "Should Ambassador Edge Stack keep CRD's when the chart is uninstalled?"
+  type: boolean
+  required: false
+  default: "true"
+  group: "CRD Management"
+  show_if: "crds.enabled=true"
+
+### Deployment Management
+- variable: daemonSet
+  label: Deploy as Daemonset
+  description: "Deploy Ambassador Edge Stack as a Daemonset? (Recommended: false)"
+  type: boolean
+  required: false
+  default: "true"
+  group: "Deployment Settings"
+- variable: replicaCount
+  label: Replica Count
+  description: "How many replicas should Ambassador Edge Stack run? (Recommended: 3)"
+  type: int
+  required: false
+  default: "3"
+  group: "Deployment Settings"
+  min: 1
+  max: 999
+  show_if: "daemonSet=false"
+
+### Service Settings
+- variable: service.type
+  label: Service Type
+  description: "Set the type of service, LoadBalancer (recommended), NodePort, or ClusterIP"
+  type: enum
+  required: false
+  default: "LoadBalancer"
+  group: "Service Settings"
+  options:
+    - "LoadBalancer"
+    - "ClusterIP"
+    - "NodePort"
+
+### Licensing
+- variable: licenseKey.createSecret
+  label: "Create License Key Secret"
+  description: "Creates the license key secret using the License Key Data."
+  type: boolean
+  required: false
+  default: "true"
+  group: "License Settings"
+- variable: licenseKey.value
+  label: "License Key Data"
+  description: "Specifies the license key to apply."
+  type: secret
+  required: false
+  default: ""
+  group: "License Settings"
+  show_if: "licenseKey.createSecret=true"
+
+### Service Catalog
+- variable: agent.enabled
+  label: "Enable Service Catalog"
+  description: "Enables the Service Catalog agent for use at https://app.getambassador.io."
+  type: boolean
+  required: false
+  default: "true"
+  group: "Service Catalog"
+- variable: agent.cloudConnectionToken
+  label: "Cloud Connection Token"
+  description: "Specifies the Token used to register a Cluster with the Service Catalog."
+  type: secret
+  required: false
+  default: ""
+  group: "Service Catalog"
+  show_if: "agent.enabled=true"
+  

--- a/packages/ambassador/package.yaml
+++ b/packages/ambassador/package.yaml
@@ -1,0 +1,2 @@
+url: https://getambassador.io/helm/ambassador-6.7.9.tgz
+packageVersion: 00

--- a/packages/ambassador/package.yaml
+++ b/packages/ambassador/package.yaml
@@ -1,2 +1,2 @@
-url: https://getambassador.io/helm/ambassador-6.7.9.tgz
+url: https://datawire-static-files.s3.amazonaws.com/charts/ambassador-6.7.11.tgz
 packageVersion: 00


### PR DESCRIPTION
Hi!  This is a request to add Ambassador Edge Stack as a partner chart in Rancher's managed apps.  I'm pretty sure I followed the readme instructions, but let me know if I missed anything, or if you have any questions.  I did test the chart itself and multiple variations of the questions on Rancher Cluster Explorer v2.5.7.  Thanks!