### PR TITLE
Cloudcasa version 2.0

### DIFF
--- a/packages/cloudcasa/cloudcasa.patch
+++ b/packages/cloudcasa/cloudcasa.patch
@@ -10,10 +10,12 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/cloudcasa/charts-original/Chart.yaml p
  keywords:
  - backup
  - Catalogic
-@@ -13,3 +13,7 @@
+@@ -12,4 +12,8 @@
+ - email: info@catalogicsoftware.com
    name: catalogicsoftware
  name: cloudcasa
- version: "1.0"
+-version: "1.0"
++version: "2.0"
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: cloudcasa

--- a/packages/cloudcasa/package.yaml
+++ b/packages/cloudcasa/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/catalogicsoftware/cloudcasa-helmchart/releases/download/cloudcasa-1.0/cloudcasa-1.0.tgz 
+url: https://github.com/catalogicsoftware/cloudcasa-helmchart/releases/download/cloudcasa-2.0/cloudcasa-2.0.tgz 
 packageVersion: 00


### PR DESCRIPTION
Pushing Cloudcasa version 2.0.

**Added supports**
1. Backup support for Azure storage accounts.
2. Snapshot copy support. 