### PR TITLE
TrilioVault for Kubernetes Operator update v2.1.0

### DIFF
--- a/packages/k8s-triliovault-operator/generated-changes/patch/Chart.yaml.patch
+++ b/packages/k8s-triliovault-operator/generated-changes/patch/Chart.yaml.patch
@@ -1,20 +1,9 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -1,6 +1,7 @@
- apiVersion: v1
- appVersion: v2.0.5
--description: K8s-TrilioVault-Operator is an operator designed to manage the K8s-TrilioVault Application Lifecycle.
-+description: K8s-TrilioVault-Operator is an operator designed to manage the K8s-TrilioVault
-+  Application Lifecycle.
- home: https://github.com/trilioData/k8s-triliovault-operator
- icon: https://www.trilio.io/wp-content/uploads/2021/01/Trilio-2020-logo-RGB-gray-green.png
- maintainers:
-@@ -9,4 +10,8 @@
- name: k8s-triliovault-operator
+@@ -11,3 +11,7 @@
  sources:
  - https://github.com/trilioData/k8s-triliovault-operator
--version: v2.0.5
-+version: 2.0.5
+ version: 2.0.1
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: k8s-triliovault-operator

--- a/packages/k8s-triliovault-operator/generated-changes/patch/Chart.yaml.patch
+++ b/packages/k8s-triliovault-operator/generated-changes/patch/Chart.yaml.patch
@@ -1,9 +1,11 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -11,3 +11,7 @@
+@@ -9,4 +9,8 @@
+ name: k8s-triliovault-operator
  sources:
  - https://github.com/trilioData/k8s-triliovault-operator
- version: 2.0.1
+-version: v2.1.0
++version: 2.1.0
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: k8s-triliovault-operator

--- a/packages/k8s-triliovault-operator/package.yaml
+++ b/packages/k8s-triliovault-operator/package.yaml
@@ -1,2 +1,2 @@
-url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-v2.0.5.tgz
+url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-2.1.0.tgz
 packageVersion: 00

--- a/packages/k8s-triliovault-operator/package.yaml
+++ b/packages/k8s-triliovault-operator/package.yaml
@@ -1,2 +1,2 @@
-url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-2.1.0.tgz
+url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-2.0.1.tgz
 packageVersion: 00

--- a/packages/k8s-triliovault-operator/package.yaml
+++ b/packages/k8s-triliovault-operator/package.yaml
@@ -1,2 +1,2 @@
-url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-2.0.1.tgz
+url: https://raw.githubusercontent.com/trilioData/triliovault--operator/master/k8s-triliovault-operator-v2.1.0.tgz
 packageVersion: 00


### PR DESCRIPTION
This PR contains:
- Update of k8s-triliovault-operator v2.1.0
- Updated patch file due to removal of 'v' from the Chart.yaml