### PR TITLE
Haproxy 1.16.1

### DIFF
--- a/packages/haproxy/generated-changes/overlay/questions.yml
+++ b/packages/haproxy/generated-changes/overlay/questions.yml
@@ -8,7 +8,7 @@ questions:
   show_subquestion_if: false
   subquestions:
   - variable: controller.image.tag
-    default: "1.5.4"
+    default: "1.6.5"
     description: "HAProxy Ingress Controller Tag"
     type: string
     label: HAProxy Ingress Controller Tag

--- a/packages/haproxy/generated-changes/patch/Chart.yaml.patch
+++ b/packages/haproxy/generated-changes/patch/Chart.yaml.patch
@@ -8,7 +8,7 @@
 +name: haproxy
  sources:
  - https://github.com/haproxytech/kubernetes-ingress
- version: 1.12.5
+ version: 1.16.1
 +annotations:
 +  catalog.cattle.io/certified: partner
 +  catalog.cattle.io/release-name: haproxy

--- a/packages/haproxy/package.yaml
+++ b/packages/haproxy/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.12.5/kubernetes-ingress-1.12.5.tgz
+url: https://github.com/haproxytech/helm-charts/releases/download/kubernetes-ingress-1.16.1/kubernetes-ingress-1.16.1.tgz
 packageVersion: 00


### PR DESCRIPTION
This PR updates the version of the HAProxy ingress controller Helm chart to v1.16.1 which includes v1.6.5 of the HAProxy Ingress Controller:

[https://github.com/haproxytech/kubernetes-ingress/releases/tag/v1.6.5](https://github.com/haproxytech/kubernetes-ingress/releases/tag/v1.6.5)