### PR TITLE
fix(chronicle): allow remote chart dependencies

### DIFF
--- a/packages/btp/chronicle/upstream.yaml
+++ b/packages/btp/chronicle/upstream.yaml
@@ -1,5 +1,6 @@
 GitRepo: https://github.com/btpworks/chronicle.git
 GitBranch: main
 GitSubdirectory: charts/chronicle
+RemoteDependencies: true
 Vendor: BTP
 DisplayName: Chronicle


### PR DESCRIPTION
Adds `RemoteDependencies: true` to the upstream.yaml file for BTP's Chronicle chart