### PR TITLE
Removing icon url from upstream.yaml

### DIFF
--- a/packages/dh2i/dxemssql/upstream.yaml
+++ b/packages/dh2i/dxemssql/upstream.yaml
@@ -6,5 +6,4 @@ ChartMetadata:
   maintainers:
   - name: DH2i Company
     email: support@dh2i.com
-    url: https://dh2i.com 
-    icon: https://clients.dh2i.com/images/DH2i_Logo_Icon.png
+    url: https://dh2i.com     


### PR DESCRIPTION
Removing icon:<url> entry from upstream.yaml since we want to use the one from Chart.yaml