### PR TITLE
Update Chronicle helm chart upstream source

### DIFF
--- a/packages/btp/chronicle/upstream.yaml
+++ b/packages/btp/chronicle/upstream.yaml
@@ -1,6 +1,4 @@
-GitRepo: https://github.com/btpworks/chronicle.git
-GitBranch: main
-GitSubdirectory: charts/chronicle
-RemoteDependencies: true
+HelmRepo: https://btp-charts-stable.s3.amazonaws.com/charts
+HelmChart: chronicle
 Vendor: BTP
 DisplayName: Chronicle


### PR DESCRIPTION
This updates the source for BTP's Chronicle helm chat from using the chart source git repo to use our published helm repository. 
 
One outstanding question before this is ready is why the location of the dependancies has changed in index.yaml