### PR TITLE
feat: adding ngrok ingress controller

### DIFF
--- a/packages/ngrok/ingress-controller/upstream.yaml
+++ b/packages/ngrok/ingress-controller/upstream.yaml
@@ -1,0 +1,6 @@
+HelmRepo: https://ngrok.github.io/kubernetes-ingress-controller
+HelmChart: kubernetes-ingress-controller
+Vendor: ngrok
+DisplayName: ngrok Ingress Controller
+ChartMetadata:
+  icon: https://assets-global.website-files.com/63ed4bc7a4b189da942a6b8c/6411ffa0b395a44345ed2b1a_Frame%201.svg


### PR DESCRIPTION
This PR adds the ngrok kubernetes ingress controller into the rancher partner charts. 