### PR TITLE
 Address warning message in the CI pipelines

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,10 +12,7 @@ jobs:
       CI_TOOLS_URL: https://github.com/samuelattwood/partner-charts-ci/releases/latest/download/partner-charts-ci-linux-amd64
 
     steps:
-      - uses: actions/setup-node@v2
-        with:
-           node-version: '16.x'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,6 +12,9 @@ jobs:
       CI_TOOLS_URL: https://github.com/samuelattwood/partner-charts-ci/releases/latest/download/partner-charts-ci-linux-amd64
 
     steps:
+      - uses: actions/setup-node@v2
+        with:
+           node-version: '16.x'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -36,5 +39,5 @@ jobs:
         run: git rebase origin/main-source
 
       - name: Validate 
-        if: "!contains(github.event.pull_request.title, '[modified charts]')"
+        if: '!contains(github.event.pull_request.title, "[modified charts]")'
         run: partner-charts-ci validate

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -39,5 +39,5 @@ jobs:
         run: git rebase origin/main-source
 
       - name: Validate 
-        if: '!contains(github.event.pull_request.title, "[modified charts]")'
+        if: "!contains(github.event.pull_request.title, '[modified charts]')"
         run: partner-charts-ci validate


### PR DESCRIPTION
### Issue

Github CI pipelines action is completed successfully, but with warning about outdated Node.js version

### Solution

Upgrade default Node.js version in the Ubuntu image from 12 to 16

### Testing done

Successfully tested

Fix #939 