### PR TITLE
Adding charts ezd-backend and ezd-crd for ezd-rp from Linux Polska

### DIFF
--- a/packages/linuxpolska/ezd-backend/upstream.yaml
+++ b/packages/linuxpolska/ezd-backend/upstream.yaml
@@ -1,0 +1,7 @@
+HelmRepo: https://linuxpolska.github.io/ezd-rp
+HelmChart: ezd-backend
+Vendor: Linux Polska
+DisplayName: LP Backend for EZD RP 
+ChartMetadata:
+  kubeVersion: '>=1.19-0'
+  icon: https://linuxpolska.com/logo/LinuxPolska-icon.png

--- a/packages/linuxpolska/ezd-backend/upstream.yaml
+++ b/packages/linuxpolska/ezd-backend/upstream.yaml
@@ -5,3 +5,7 @@ DisplayName: LP Backend for EZD RP
 ChartMetadata:
   kubeVersion: '>=1.19-0'
   icon: https://linuxpolska.com/logo/LinuxPolska-icon.png
+  maintainers:
+  - name: Linux Polska
+    email: support@linuxpolska.com
+    url: https://linuxpolska.com/en/

--- a/packages/linuxpolska/ezd-crd/upstream.yaml
+++ b/packages/linuxpolska/ezd-crd/upstream.yaml
@@ -1,0 +1,7 @@
+HelmRepo: https://linuxpolska.github.io/ezd-rp
+HelmChart: ezd-crd
+Vendor: Linux Polska
+DisplayName: CRDs for LP Backend
+ChartMetadata:
+  kubeVersion: '>=1.19-0'
+  icon: https://linuxpolska.com/logo/LinuxPolska-icon.png

--- a/packages/linuxpolska/ezd-crd/upstream.yaml
+++ b/packages/linuxpolska/ezd-crd/upstream.yaml
@@ -5,3 +5,7 @@ DisplayName: CRDs for LP Backend
 ChartMetadata:
   kubeVersion: '>=1.19-0'
   icon: https://linuxpolska.com/logo/LinuxPolska-icon.png
+  maintainers:
+  - name: Linux Polska
+    email: support@linuxpolska.com
+    url: https://linuxpolska.com/en/


### PR DESCRIPTION
Our package contains set of necessary services which allow to lunch EZD-RP application developed by NASK on Kubernetes using [Helm](https://github.com/helm/helm).

Pull request contains two helm charts:
- ezd-crd
- ezd-backend  