### PR TITLE
Submitting dh2i/dxoperator and dh2i/dxenterprisesqlag

### DIFF
--- a/packages/dh2i/dxenterprisesqlag/upstream.yaml
+++ b/packages/dh2i/dxenterprisesqlag/upstream.yaml
@@ -1,0 +1,9 @@
+HelmRepo: https://raw.githubusercontent.com/dh2i/helm/main
+HelmChart: dxenterprisesqlag
+Vendor: dh2i
+DisplayName: DxEnterpriseSqlAg
+ChartMetadata:
+  maintainers:
+  - name: DH2i Company
+    email: support@dh2i.com
+    url: https://dh2i.com     

--- a/packages/dh2i/dxoperator/upstream.yaml
+++ b/packages/dh2i/dxoperator/upstream.yaml
@@ -1,0 +1,9 @@
+HelmRepo: https://raw.githubusercontent.com/dh2i/helm/main
+HelmChart: dxoperator
+Vendor: dh2i
+DisplayName: DxOperator
+ChartMetadata:
+  maintainers:
+  - name: DH2i Company
+    email: support@dh2i.com
+    url: https://dh2i.com     


### PR DESCRIPTION
This is a pull request for adding `dh2i/dxoperator` and `dh2i/dxenterprisesqlag` to the Rancher Partner Charts.