### PR TITLE
Use `rancher/partner-charts-ci` in CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CI_TOOLS_URL: https://github.com/samuelattwood/partner-charts-ci/releases/latest/download/partner-charts-ci-linux-amd64
+      CI_TOOLS_URL: https://github.com/rancher/partner-charts-ci/releases/latest/download/partner-charts-ci-linux-amd64
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/pull-ci-scripts
+++ b/scripts/pull-ci-scripts
@@ -2,8 +2,8 @@
 set -e
 
 CI_BINARY="partner-charts-ci"
-CI_BINARY_URL_BASE="https://github.com/samuelattwood/partner-charts-ci/releases/latest/download"
-CI_GIT_REPO="https://github.com/samuelattwood/partner-charts-ci.git"
+CI_BINARY_URL_BASE="https://github.com/rancher/partner-charts-ci/releases/latest/download"
+CI_GIT_REPO="https://github.com/rancher/partner-charts-ci.git"
 
 mkdir -p bin
 


### PR DESCRIPTION
Currently we use `samuelattwood/partner-charts-ci` in the CI in this repo. We want to use `rancher/partner-charts-ci` so that CI is under our control.