### PR TITLE
Automate updates of existing helm charts

### DIFF
--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -16,26 +16,29 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+    - name: Get rancher/partner-charts secrets out of vault
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          github/repo/rancher/partner-charts/github/app-credentials appId | APP_ID ;
+          github/repo/rancher/partner-charts/github/app-credentials privateKey | PRIVATE_KEY
+
+    - name: Generate short-lived github app token
+      uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+
     - name: Update main-source branch
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_WORKFLOW: ${{ github.workflow }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         scripts/pull-ci-scripts
-        BRANCH="auto-update/$(date '+%s')"
-        git checkout -b "$BRANCH"
         bin/partner-charts-ci auto
 
         # exit if there are no changes
-        git diff --quiet main-source "$BRANCH" && exit 0
+        git diff --quiet origin/main-source main-source && exit 0
 
-        # close all existing PRs from branches starting with "auto-update"
-        gh pr --repo "$GITHUB_REPOSITORY" list --search 'head:auto-update' --json 'headRefName' --jq '.[] | join("\n")' | \
-          xargs --no-run-if-empty -n 1 gh pr --repo "$GITHUB_REPOSITORY" close
-
-        # push changes
-        git push --set-upstream origin "$BRANCH"
-        TITLE="[AUTOMATED] Auto-update charts on main-source"
-        BODY="This PR was created by the \"$GITHUB_WORKFLOW\" workflow. It auto-updates the helm charts on the main-source branch."
-        gh pr create --repo "$GITHUB_REPOSITORY" --base main-source --head "$BRANCH" --title "$TITLE" --body "$BODY"
+        git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/rancher/partner-charts
+        git push origin main-source

--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -17,14 +17,34 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+    - name: Get rancher/partner-charts secrets out of vault
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          github/repo/rancher/partner-charts/github/app-credentials appId | APP_ID ;
+          github/repo/rancher/partner-charts/github/app-credentials privateKey | PRIVATE_KEY
+
+    - name: Generate short-lived github app token
+      uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+
     - name: Update main branch with latest from main-source
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         # checkout action only fetches main-source, so we need to fetch main
         git fetch origin main --depth 1
         git checkout main
+
         git rm -r assets index.yaml
         git checkout main-source -- assets index.yaml
+
         # exit if there are no changes
         git diff-index --quiet HEAD assets index.yaml && exit 0
-        git commit -m "Update partner charts"
+
+        git commit -m "Release partner charts"
+        git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/rancher/partner-charts
         git push origin


### PR DESCRIPTION
This is a second try at #983. For context see https://github.com/rancherlabs/eio/issues/2112 and the JIRA issue.

A quick summary: an installation access token is used to authenticate as a github app when pushing code. This github app is given an exception to the branch protection rules for this repo, which normally prevent pushes directly to the `main-source` and `main` branches.

I tried to get automated updates working with PRs, but github does not allow this without a human in the loop. This is why these workflows now simply create commits on `main-source` and `main` and push them.

I tested the parts of this that I could, but github/our setup makes full testing on a fork impossible. I am confident that these changes won't screw this repo up, but I am not confident that it will work on the first try.