### PR TITLE
Add CODEOWNERS file to `main` branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Reviewer
+* @rancher/mapps


### PR DESCRIPTION
I noticed that `CODEOWNERS` was missing on the `main` branch. This PR corrects that.

`CODEOWNERS` is already present on the `main-source` branch. 