### PR TITLE
Add necessary permissions for accessing hashicorp vault to `update-main.yml` and `update-main-source.yml`

### DIFF
--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -1,4 +1,4 @@
-name: Auto-update charts
+name: Auto-update charts on main-source branch
 
 on:
   workflow_dispatch: {}
@@ -7,6 +7,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -1,13 +1,15 @@
 name: Update main branch from main-source
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     branches:
       - main-source
 
 jobs:
   update:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
When running the `update-main-source.yml` workflow (see https://github.com/rancher/partner-charts/actions/runs/8607065954/job/23586824809 for an example) an error was occurring. If you compare this workflow to the example in the [`rancher-eio/read-vault-secrets`](https://github.com/rancher-eio/read-vault-secrets) repo, you might notice that there was a missing `permissions` statement on the job. This PR fixes that.

This was also a problem in the `update-main.yml` workflow, so I fixed it there as well.

I can't test these PRs until they're merged, but hopefully this is the last one.