### PR TITLE
Fix vault path for app credentials in `main-source` update automation

### DIFF
--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -22,8 +22,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          github/repo/rancher/partner-charts/github/app-credentials appId | APP_ID ;
-          github/repo/rancher/partner-charts/github/app-credentials privateKey | PRIVATE_KEY
+          secret/data/github/repo/rancher/partner-charts/github/app-credentials appId | APP_ID ;
+          secret/data/github/repo/rancher/partner-charts/github/app-credentials privateKey | PRIVATE_KEY
 
     - name: Generate short-lived github app token
       uses: actions/create-github-app-token@v1


### PR DESCRIPTION
The vault path was wrong. This PR fixes it.