### PR TITLE
updating call to auto partner-charts-ci with --icons

### DIFF
--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Update main-source branch
       run: |
         scripts/pull-ci-scripts
-        bin/partner-charts-ci auto
+        bin/partner-charts-ci auto --icons
 
         # exit if there are no changes
         git diff --quiet origin/main-source main-source && exit 0


### PR DESCRIPTION
### Problem
Partner Charts has a lot of Charts with several logos being fetched online. 
This causes some problems for AirGap Environments. 


### Continuing solution from:
[Partner Charts Logos PR](https://github.com/rancher/partner-charts/pull/1016)
[Related partner-charts-ci PR](https://github.com/rancher/partner-charts-ci/pull/3)

