### PR TITLE
Remove redundant `package.yaml` files

### DIFF
--- a/packages/nats/nats/package.yaml
+++ b/packages/nats/nats/package.yaml
@@ -1,2 +1,0 @@
-url: https://github.com/nats-io/k8s/releases/download/v0.10.0/nats-0.10.0.tgz
-packageVersion: 00

--- a/packages/new-relic/nri-bundle/package.yaml
+++ b/packages/new-relic/nri-bundle/package.yaml
@@ -1,3 +1,0 @@
-url: https://github.com/newrelic/helm-charts/releases/download/nri-bundle-4.3.2/nri-bundle-4.3.2.tgz
-subDirectory: nri-bundle
-packageVersion: 00


### PR DESCRIPTION
There are two packages that have *both* `package.yaml` and `upstream.yaml` files. This doesn't make any sense. `package.yaml` files are referred to in a couple places in the `partner-charts-ci` code, but none of these places are used under the current configuration of partner-charts. This has been the case for a long time.

This PR does the cleanup of removing these redundant `package.yaml` files. I have verified that everything (`partner-charts-ci auto`, using the repository from the Rancher UI) works with these changes.