### PR TITLE
Sync `index.yaml` with actual state of `assets/`

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -17536,32 +17536,6 @@ entries:
     urls:
     - assets/clastix/kamaji-console-0.0.4.tgz
     version: 0.0.4
-  - annotations:
-      catalog.cattle.io/certified: partner
-      catalog.cattle.io/display-name: Kamaji Console
-      catalog.cattle.io/kube-version: '>=1.21.0-0'
-      catalog.cattle.io/release-name: kamaji-console
-    apiVersion: v2
-    appVersion: v0.0.1
-    created: "2023-06-19T14:29:43.008419723+02:00"
-    description: Kamaji deploys and operates Kubernetes at scale with a fraction of
-      the operational burden. This chart install a console for Kamaji.
-    digest: 46002955458fc5fde4eb0ace6f3abfb9befe17d9b21734ed03786f11e0ed5d24
-    home: https://github.com/clastix/kamaji-console
-    icon: file://assets/icons/kamaji-console.png
-    kubeVersion: '>=1.21.0-0'
-    maintainers:
-    - email: dario@tranchitella.eu
-      name: Dario Tranchitella
-    - email: me@bsctl.io
-      name: Adriano Pezzuto
-    name: kamaji-console
-    sources:
-    - https://github.com/clastix/kamaji-console
-    type: application
-    urls:
-    - assets/clastix/kamaji-console-0.0.3.tgz
-    version: 0.0.3
   kong:
   - annotations:
       catalog.cattle.io/certified: partner
@@ -29826,7 +29800,7 @@ entries:
       tags:
       - defaultDB
     description: A Helm chart for Kubernetes to install the Shipa Control Plane
-    digest: e02796981c55f681bc10a1e626217dc08b9bbc6010cba9839da07002086208bc
+    digest: d7f72f6321a9319749c5c683a718cdb1aabf52f838e4f0f1f658cdf6d852d8ff
     home: https://www.shipa.io
     icon: https://www.shipa.io/wp-content/uploads/2020/11/Shipa-banner-768x307.png
     keywords:
@@ -34317,6 +34291,84 @@ entries:
       catalog.cattle.io/release-name: yugabyte
       charts.openshift.io/name: yugabyte
     apiVersion: v2
+    appVersion: 2.18.4.2-b2
+    created: "2023-10-26T13:20:40.716536152Z"
+    description: YugabyteDB is the high-performance distributed SQL database for building
+      global, internet-scale apps.
+    digest: c7e62c63d34672822a8571b2d11ceee06a158b981f66a8fd1bff3cd6dc7919a6
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugabyte.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugabyte
+    sources:
+    - https://github.com/yugabyte/yugabyte-db
+    urls:
+    - assets/yugabyte/yugabyte-2.18.4+2.tgz
+    version: 2.18.4+2
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugabyte
+      charts.openshift.io/name: yugabyte
+    apiVersion: v2
+    appVersion: 2.18.4.1-b3
+    created: "2023-10-26T13:20:40.716536152Z"
+    description: YugabyteDB is the high-performance distributed SQL database for building
+      global, internet-scale apps.
+    digest: ec7d599146bdca2fe1242fcc53ae55b5a386daf3bd494e31413680e39b64f81a
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugabyte.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugabyte
+    sources:
+    - https://github.com/yugabyte/yugabyte-db
+    urls:
+    - assets/yugabyte/yugabyte-2.18.4+1.tgz
+    version: 2.18.4+1
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugabyte
+      charts.openshift.io/name: yugabyte
+    apiVersion: v2
+    appVersion: 2.18.3.1-b1
+    created: "2023-09-22T15:03:28.304796229Z"
+    description: YugabyteDB is the high-performance distributed SQL database for building
+      global, internet-scale apps.
+    digest: c82a4c98d203677453deccf221f1e9a51287d2df79df697fdaea79fac342d5e2
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugabyte.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugabyte
+    sources:
+    - https://github.com/yugabyte/yugabyte-db
+    urls:
+    - assets/yugabyte/yugabyte-2.18.3+1.tgz
+    version: 2.18.3+1
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugabyte
+      charts.openshift.io/name: yugabyte
+    apiVersion: v2
     appVersion: 2.18.3.0-b75
     created: "2023-09-22T15:03:28.304796229Z"
     description: YugabyteDB is the high-performance distributed SQL database for building
@@ -34798,6 +34850,84 @@ entries:
       catalog.cattle.io/release-name: yugaware
       charts.openshift.io/name: yugaware
     apiVersion: v2
+    appVersion: 2.18.4.2-b2
+    created: "2023-10-26T13:20:40.762634168Z"
+    description: YugabyteDB Anywhere provides deployment, orchestration, and monitoring
+      for managing YugabyteDB clusters. YugabyteDB Anywhere can create a YugabyteDB
+      cluster with multiple pods provided by Kubernetes or OpenShift and logically
+      grouped together to form one logical distributed database.
+    digest: 9a32edaf0382d1e4606211fdaf07540499e519a2c46291272b30b82afea9115b
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugaware.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugaware
+    urls:
+    - assets/yugabyte/yugaware-2.18.4+2.tgz
+    version: 2.18.4+2
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB Anywhere
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugaware
+      charts.openshift.io/name: yugaware
+    apiVersion: v2
+    appVersion: 2.18.4.1-b3
+    created: "2023-10-26T13:20:40.762634168Z"
+    description: YugabyteDB Anywhere provides deployment, orchestration, and monitoring
+      for managing YugabyteDB clusters. YugabyteDB Anywhere can create a YugabyteDB
+      cluster with multiple pods provided by Kubernetes or OpenShift and logically
+      grouped together to form one logical distributed database.
+    digest: dd0867bf7c12f16e358bef2dead6d50eefb3b9a131480569093f79ce7ba03b5c
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugaware.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugaware
+    urls:
+    - assets/yugabyte/yugaware-2.18.4+1.tgz
+    version: 2.18.4+1
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB Anywhere
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugaware
+      charts.openshift.io/name: yugaware
+    apiVersion: v2
+    appVersion: 2.18.3.1-b1
+    created: "2023-09-22T15:03:28.347126179Z"
+    description: YugabyteDB Anywhere provides deployment, orchestration, and monitoring
+      for managing YugabyteDB clusters. YugabyteDB Anywhere can create a YugabyteDB
+      cluster with multiple pods provided by Kubernetes or OpenShift and logically
+      grouped together to form one logical distributed database.
+    digest: f67c0ba761815d388746765a5b095166f274266075c586b0b00e6e07cbecd4c7
+    home: https://www.yugabyte.com
+    icon: file://assets/icons/yugaware.jpg
+    kubeVersion: '>=1.18-0'
+    maintainers:
+    - email: sanketh@yugabyte.com
+      name: Sanketh Indarapu
+    - email: gjalla@yugabyte.com
+      name: Govardhan Reddy Jalla
+    name: yugaware
+    urls:
+    - assets/yugabyte/yugaware-2.18.3+1.tgz
+    version: 2.18.3+1
+  - annotations:
+      catalog.cattle.io/certified: partner
+      catalog.cattle.io/display-name: YugabyteDB Anywhere
+      catalog.cattle.io/kube-version: '>=1.18-0'
+      catalog.cattle.io/release-name: yugaware
+      charts.openshift.io/name: yugaware
+    apiVersion: v2
     appVersion: 2.18.3.0-b75
     created: "2023-09-22T15:03:28.347126179Z"
     description: YugabyteDB Anywhere provides deployment, orchestration, and monitoring
@@ -35153,4 +35283,4 @@ entries:
     urls:
     - assets/netfoundry/ziti-host-1.5.1.tgz
     version: 1.5.1
-generated: "2021-06-23T17:44:55.374388-07:00"
+generated: "2024-07-04T12:49:04.594976755-06:00"


### PR DESCRIPTION
In https://github.com/rancher/partner-charts-ci/pull/13, the function that writes `index.yaml` (`writeIndex()`) was updated. The old version of `writeIndex()` did not modify existing chart versions (a chart version would be, for example, `entries.access-broker[0]`). This caused it to get out of sync with the state of the actual charts that are present in the `assets/` directory. The new version of `writeIndex()` ensures that the state of `index.yaml` reflects the state of `assets/`.

The change in this PR was produced simply by running the new version of `writeIndex()`. I am making this a separate PR so that we don't have to make these changes during the migration necessitated by https://github.com/rancher/partner-charts-ci/pull/13.

I have tested that the current version of `writeIndex()` (i.e. before we merge https://github.com/rancher/partner-charts-ci/pull/13) will not make any changes to the modified `index.yaml` from this PR. So, it is safe to merge this.