### PR TITLE
Remove `--icons` argument from `partner-charts-ci auto` call

### DIFF
--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Update main-source branch
       run: |
         scripts/pull-scripts
-        bin/partner-charts-ci auto --icons
+        bin/partner-charts-ci auto
 
         # exit if there are no changes
         git diff --quiet origin/main-source main-source && exit 0


### PR DESCRIPTION
This option is no longer needed, and will result in failure of the workflow if we do not remove it.