### PR TITLE
Update `GitSubDirectory` field of `codefresh/cf-runtime`

### DIFF
--- a/packages/codefresh/cf-runtime/upstream.yaml
+++ b/packages/codefresh/cf-runtime/upstream.yaml
@@ -1,5 +1,5 @@
 GitRepo: https://github.com/codefresh-io/venona.git
-GitSubDirectory: .deploy/cf-runtime
+GitSubDirectory: charts/cf-runtime
 GitHubRelease: true
 Vendor: Codefresh
 DisplayName: Codefresh


### PR DESCRIPTION
Currently we are getting an error when we run `partner-charts-ci auto` for the `codefresh/cf-runtime` package:
```
failed to populate codefresh/cf-runtime: failed to fetch data from upstream: git subdirectory '.deploy/cf-runtime' does not exist
```
This is happening because the value of `GitSubDirectory` in the `upstream.yaml` for `codefresh/cf-runtime` is `.deploy/cf-runtime`, which is a path that was moved to `charts/cf-runtime` in the commit `311172a86145e373a687783fccba65142684fde7` in the repository (https://github.com/codefresh-io/venona).

This PR fixes this problem.