### PR TITLE
Modify value of `HelmRepo` for `confluent/confluent-for-kubernetes`

### DIFF
--- a/packages/confluent/confluent-for-kubernetes/upstream.yaml
+++ b/packages/confluent/confluent-for-kubernetes/upstream.yaml
@@ -1,7 +1,7 @@
-HelmRepo: https://confluent-helm-prod.s3-us-west-2.amazonaws.com/helm
+HelmRepo: https://packages.confluent.io/helm
 HelmChart: confluent-for-kubernetes
 Vendor: Confluent
-DisplayName: Confluent For Kubernetes
+DisplayName: Confluent for Kubernetes
 ChartMetadata:
   icon: https://cdn.confluent.io/wp-content/uploads/seo-logo-meadow.png
   kubeVersion: '>=1.15-0'


### PR DESCRIPTION
When `partner-charts-ci auto` is run, the `confluent/confluent-for-kubernetes` package gives the following error:
```
failed to populate confluent/confluent-for-kubernetes: failed to fetch data from upstream: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type repo.IndexFile
```
This is happening because the original confluent repo appears to have been decommissioned. [The docs](https://docs.confluent.io/operator/current/co-deploy-cfk.html#deploy-co-from-confluent-s-helm-repo) now say to use https://packages.confluent.io/helm. This PR makes this change.