### PR TITLE
Remove invalid icon URLs in `upstream.yaml` files

### DIFF
--- a/packages/cloudcasa/cloudcasa/upstream.yaml
+++ b/packages/cloudcasa/cloudcasa/upstream.yaml
@@ -2,5 +2,3 @@ HelmRepo: https://catalogicsoftware.github.io/cloudcasa-helmchart
 HelmChart: cloudcasa
 Vendor: CloudCasa
 DisplayName: CloudCasa
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/cloudcasa.png

--- a/packages/dell/csi-isilon/upstream.yaml
+++ b/packages/dell/csi-isilon/upstream.yaml
@@ -4,5 +4,3 @@ GitHubRelease: true
 Vendor: Dell
 DisplayName: Dell CSI PowerScale
 ReleaseName: isilon
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/dell.png

--- a/packages/dell/csi-powermax/upstream.yaml
+++ b/packages/dell/csi-powermax/upstream.yaml
@@ -3,5 +3,3 @@ GitSubdirectory: charts/csi-powermax
 GitHubRelease: true
 Vendor: Dell
 DisplayName: Dell CSI PowerMax
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/dell.png

--- a/packages/dell/csi-powerstore/upstream.yaml
+++ b/packages/dell/csi-powerstore/upstream.yaml
@@ -4,5 +4,3 @@ GitHubRelease: true
 Vendor: Dell
 DisplayName: Dell CSI PowerStore
 ReleaseName: powerstore
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/dell.png

--- a/packages/dell/csi-unity/upstream.yaml
+++ b/packages/dell/csi-unity/upstream.yaml
@@ -4,5 +4,3 @@ GitHubRelease: true
 Vendor: Dell
 DisplayName: Dell CSI Unity
 ReleaseName: unity
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/dell.png

--- a/packages/dell/csi-vxflexos/upstream.yaml
+++ b/packages/dell/csi-vxflexos/upstream.yaml
@@ -5,5 +5,3 @@ Vendor: Dell
 DisplayName: Dell CSI PowerFlex
 ReleaseName: vxflexos
 Namespace: vxflexos
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/dell.png

--- a/packages/kubecost/cost-analyzer/upstream.yaml
+++ b/packages/kubecost/cost-analyzer/upstream.yaml
@@ -2,5 +2,3 @@ HelmRepo: https://kubecost.github.io/cost-analyzer
 HelmChart: cost-analyzer 
 Vendor: Kubecost
 DisplayName: Kubecost
-ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/kubecost.png

--- a/packages/netfoundry/ziti-host/upstream.yaml
+++ b/packages/netfoundry/ziti-host/upstream.yaml
@@ -3,5 +3,4 @@ HelmChart: ziti-host
 Vendor: NetFoundry
 DisplayName: OpenZiti Service-Hosting
 ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/ziti-host.png
   kubeVersion: '>=1.20-0'

--- a/packages/triggermesh/triggermesh/upstream.yaml
+++ b/packages/triggermesh/triggermesh/upstream.yaml
@@ -3,5 +3,4 @@ HelmChart: triggermesh
 Vendor: Triggermesh
 DisplayName: TriggerMesh
 ChartMetadata:
-  icon: https://partner-charts.rancher.io/assets/logos/triggermesh.svg
   kubeVersion: '>=1.20-0'


### PR DESCRIPTION
Like it says in the title. These values were overlaid onto the icon value from the upstream chart when integrating new chart versions. Now, that won't happen: the icon value from the upstream chart will be used.

Of course, this doesn't *really* matter because the icon value in `Chart.yaml` is overwritten in `integrateCharts()`, and the icon value in `index.yaml` is overwritten in `writeIndex()`. But it is good to clean this up.