### PR TITLE
Add `linux-polska/neuvector-security`

### DIFF
--- a/packages/linux-polska/neuvector-security/upstream.yaml
+++ b/packages/linux-polska/neuvector-security/upstream.yaml
@@ -1,0 +1,11 @@
+HelmRepo: https://sourcemation.github.io/charts
+HelmChart: neuvector-security
+Vendor: Linux Polska
+DisplayName: NeuVector (Add-on) - Security Rules
+ChartMetadata:
+  kubeVersion: '>=1.25-0'
+  icon: https://linuxpolska.com/logo/LinuxPolska-icon.png
+  maintainers:
+  - name: Linux Polska
+    email: support@linuxpolska.com
+    url: https://linuxpolska.com/en/


### PR DESCRIPTION
Chart requires  SUSE Neuvector solution to work. The add-on uses following Neuvectr's CRDs:
* nvclustersecurityrules.neuvector.com
* nvdlpsecurityrules.neuvector.com

