### PR TITLE
Deprecate the stackstate-k8s-agent in favor of the SUSE Observability agent

### DIFF
--- a/packages/stackstate/stackstate-k8s-agent/upstream.yaml
+++ b/packages/stackstate/stackstate-k8s-agent/upstream.yaml
@@ -1,6 +1,7 @@
 HelmRepo: https://helm.stackstate.io
 HelmChart: stackstate-k8s-agent
 Vendor: StackState
+Deprecated: true
 DisplayName: StackState Agent
 ChartMetadata:
   kubeVersion: '>=1.19.0-0'


### PR DESCRIPTION
StackState was rebranded to SUSE observability and the agent chart to SUSE Observability Agent

The SUSE Observability Agent chart is distributed as part of the rancher prime chart repository, so this chart is now deprecated.