### PR TITLE
Use `update` subcommand

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,18 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CI_TOOLS_URL: https://github.com/rancher/partner-charts-ci/releases/latest/download/partner-charts-ci-linux-amd64
-
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Fetch CI Tools
-        run: |
-          curl -s -L -o /usr/local/bin/partner-charts-ci $CI_TOOLS_URL
-          chmod +x /usr/local/bin/partner-charts-ci
+        run: scripts/pull-scripts
 
       - name: Checkout into branch
         run: git checkout -b staging-pr-workflow
@@ -37,4 +32,4 @@ jobs:
 
       - name: Validate 
         if: "!contains(github.event.pull_request.title, '[modified charts]')"
-        run: partner-charts-ci validate
+        run: bin/partner-charts-ci validate

--- a/.github/workflows/update-main-source.yml
+++ b/.github/workflows/update-main-source.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Update main-source branch
       run: |
         scripts/pull-scripts
-        bin/partner-charts-ci auto
+        bin/partner-charts-ci update --commit
 
         # exit if there are no changes
         git diff --quiet origin/main-source main-source && exit 0

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ You can confirm the package entry with `bin/partner-charts-ci list` which will l
 ```bash
 export PACKAGE=<vendor>/<chart>
 ```
-#### 3. Run the 'auto' or 'stage' function
+#### 3. Run the 'update' subcommand
 The 'auto' subcommand will run the complete CI process.
 The 'stage' subcommand will do the same process but will not create a git commit when it completes.
 ```bash
-bin/partner-charts-ci auto
+bin/partner-charts-ci update --commit
 ```
 #### 4. Validate your changes
 ```bash
@@ -124,7 +124,7 @@ bin/partner-charts-ci validate
 a) Get scripts: scripts/pull-scripts
 b) List and find your company name/chart: bin/partner-charts-ci list | grep <vendor>
 c) set PACKAGE variable to your company/chart: export PACKAGE=<vendor>/<chart-name> or export PACKAGE=<vendor>
-d) Run bin/partner-charts-ci stage or auto # the new charts should be downloaded
+d) Run bin/partner-charts-ci update # the new charts should be downloaded
 ```
 2.  In your local `partner-charts` directory start a python3 http server:
 ```bash
@@ -298,7 +298,7 @@ git rm -r charts/<chart>
 #### 6. Stage your changes (To make sure the config works, and to setup the new charts and assets directories)
 ```bash
 export PACKAGE=<vendor>/<chart>
-bin/partner-charts-ci stage
+bin/partner-charts-ci update
 ```
 #### 7. Move the old assets files to the new directory (Sometimes this is unchanged but most times it does change)
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ git push origin <your_branch>
 
 
 ## Testing your configuration
-If you would like to test your configuration using the CI tool, simply run the provided script in `scripts/pull-scripts` to download the binary. The 'auto' function is what will be run to download and store your chart.
 
-#### 1. Download the binary
+If you would like to test your configuration, download `partner-charts-ci`
+using `scripts/pull-scripts`. The `update` function can be used to download and
+integrate your chart.
+
+#### 1. Download `partner-charts-ci`
 ```bash
 scripts/pull-scripts
 ```
@@ -108,9 +111,9 @@ You can confirm the package entry with `bin/partner-charts-ci list` which will l
 ```bash
 export PACKAGE=<vendor>/<chart>
 ```
-#### 3. Run the 'update' subcommand
-The 'auto' subcommand will run the complete CI process.
-The 'stage' subcommand will do the same process but will not create a git commit when it completes.
+#### 3. Run the `update` subcommand
+The `update` subcommand will go through the CI process. Append the `--commit`
+flag if you want it to create a git commit when it completes.
 ```bash
 bin/partner-charts-ci update --commit
 ```

--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -24,7 +24,7 @@ else
     #Fall back to local build
     git clone --depth 1 -b main ${CI_GIT_REPO} src
     cd src
-    make
+    go build -o bin/${CI_BINARY}
     mv bin/${CI_BINARY} ../bin
     cd ..
     rm -rf src
@@ -34,4 +34,4 @@ if [[ ! -z ${BINARY_NAME} ]]; then
     curl -s -L -o bin/${CI_BINARY} ${CI_BINARY_URL_BASE}/${BINARY_NAME}
 fi
 
-chmod +x bin/partner-charts-ci
+chmod +x bin/${CI_BINARY}


### PR DESCRIPTION
In https://github.com/rancher/partner-charts-ci/pull/41 the `stage` and `auto` subcommands will be replaced by a single `update` subcommand. This PR makes the necessary changes to this repository to use this new subcommand. It also corrects a few minor issues with this repo's CI.

This PR must only be merged once https://github.com/rancher/partner-charts-ci/pull/41 is merged and `partner-charts-ci` has been released.