### PR TITLE
Revert addition of "define an icon" requirement for upstream charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ for inclusion in this repository. Your software's helm chart must:
 * have `kubeVersion` set in the chart's metadata
 * contain an `app-readme.md` file (refer to the [`partner-charts-ci` documentation](https://github.com/rancher/partner-charts-ci) for more details)
 * be deployable from the current version of Rancher with the default values
-* define an icon
 
 Meeting these requirements ensures that Rancher users can easily deploy your
 software.


### PR DESCRIPTION
There are a number of charts already in the partner charts repository that define `icon` via `ChartMetadata` in `upstream.yaml`. Also, if the icon for a chart is in place in `assets/icons/` already, the `icon` field of `Chart.yaml` is not checked. All that to say that `icon` is not required in the upstream chart's `Chart.yaml`.