### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/charts/hashicorp/consul/2.0.0/templates/generate-manifests-apply-job.yaml
+++ b/charts/hashicorp/consul/2.0.0/templates/generate-manifests-apply-job.yaml
@@ -42,7 +42,7 @@ spec:
       {{- if not .Values.global.openshift.enabled }}
       containers:
       - name: apply
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args:

--- a/charts/linux-polska/ezd-crd/1.9.0/charts/redis-operator/templates/tests/test-connection.yaml
+++ b/charts/linux-polska/ezd-crd/1.9.0/charts/redis-operator/templates/tests/test-connection.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: soldevelo/kubectl:latest
       command:
         - sh
         - -c

--- a/charts/linux-polska/ezd-crd/2.0.0/charts/redis-operator/templates/tests/test-connection.yaml
+++ b/charts/linux-polska/ezd-crd/2.0.0/charts/redis-operator/templates/tests/test-connection.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: soldevelo/kubectl:latest
       command:
         - sh
         - -c


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)