### PR TITLE
Update app-readme.md for libredb/libredb-studio

### DIFF
--- a/packages/libredb/libredb-studio/overlay/app-readme.md
+++ b/packages/libredb/libredb-studio/overlay/app-readme.md
@@ -1,12 +1,12 @@
 # LibreDB Studio
 
-LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse and Apache Druid directly from the browser.
+LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects to sixteen database engines directly from the browser.
 
 Use cases:
 
 * Browser-based database management
-  * Browse schemas, run queries and manage data across ten engines — PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse and Apache Druid — from a single web interface, with no desktop client to install.
+  * Browse schemas and run queries across sixteen engines: PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra. Editing data follows the engine rather than the IDE: inline row editing on PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL and DuckDB, and everywhere else the controls are reported as unsupported rather than offered and then failed.
 * AI-assisted querying
-  * An optional AI assistant (bring your own key: Gemini, OpenAI, or a local model) writes and explains SQL from natural language. It stays off unless you configure a provider.
+  * An optional AI assistant (bring your own key: Gemini, OpenAI, or a local model) explains a query in plain English from the engine's own EXPLAIN plan, on PostgreSQL, MySQL, SQLite, libSQL, DuckDB, Couchbase, ClickHouse, Apache Druid and Apache Trino, and runs a read-only investigation agent on PostgreSQL, SQLite and DuckDB where the database, not the IDE, enforces the read-only session. It stays off unless you configure a provider.
 * Self-hosted data
-  * Runs entirely on your own infrastructure with SQLite storage by default, so no external database is required to operate the IDE itself. Installs from the Rancher Apps catalog with default values — first-run admin credentials are generated automatically and printed to the pod log.
+  * Runs entirely on your own infrastructure, so no external database is required to operate the IDE itself. Installs from the Rancher Apps catalog with default values: first-run admin credentials are generated automatically and printed to the pod log.


### PR DESCRIPTION
The app-readme still names ten engines.
The chart's own description names sixteen, so the text Rancher shows in the Apps view is behind the chart it ships with.

This brings the overlay back in line with the chart description and with the listing copy we maintain upstream.
Only `packages/libredb/libredb-studio/overlay/app-readme.md` changes.
No chart version is added: nightly CI already picks our releases up from the helm repo.
